### PR TITLE
Don't allow Block element inside Block element

### DIFF
--- a/packages/stylelint-config-swissquote/src/rules/__tests__/no-block-inside-block.js
+++ b/packages/stylelint-config-swissquote/src/rules/__tests__/no-block-inside-block.js
@@ -10,9 +10,10 @@ describe("tests for no-block-inside-block", () => {
         line: 1,
         text: "A block should not depend on another block directly"
       })
-    ));
+    )
+  );
 
-  it("Block inside Element of another Block is not allowed", () =>
+  it("Block inside Element of another Block should not be allowed", () =>
     createRuleTester.test(rule, ".Component1 { .Component1__element { .Component2 {}}}").then(t =>
       expect(t).toEqual({
         column: 38,
@@ -20,9 +21,10 @@ describe("tests for no-block-inside-block", () => {
         text: "A block should not depend on another block directly",
         warnings: 1
       })
-    ));
+    )
+  );
 
-  it("Block inside Element with nesting selector of another Block is not allowed", () =>
+  it("Block inside Element with nesting selector of another Block should not be allowed", () =>
     createRuleTester.test(rule, ".Component1 { & .Component1__element { .Component2 {} } }").then(t =>
       expect(t).toEqual({
         column: 40,
@@ -30,9 +32,10 @@ describe("tests for no-block-inside-block", () => {
         text: "A block should not depend on another block directly",
         warnings: 1
       })
-    ));
+    )
+  );
 
-  it("Block selector in subling Element is not allowed", () =>
+  it("Block selector in subling Element should not be allowed", () =>
     createRuleTester.test(rule, ".Component1 { .Component1__element .Component2 {}}").then(t =>
       expect(t).toEqual({
         column: 15,
@@ -40,9 +43,10 @@ describe("tests for no-block-inside-block", () => {
         text: "A block should not depend on another block directly",
         warnings: 1
       })
-    ));
+    )
+  );
 
-  it("Block selector in child Element is not allowed", () =>
+  it("Block selector in child Element should not be allowed", () =>
     createRuleTester.test(rule, ".Component1 { .Component1__element > .Component2 {}}").then(t =>
       expect(t).toEqual({
         column: 15,
@@ -50,8 +54,26 @@ describe("tests for no-block-inside-block", () => {
         text: "A block should not depend on another block directly",
         warnings: 1
       })
-    ));
+    )
+  );
 
-  it("Two independent blocks is allowed", () =>
-    createRuleTester.test(rule, ".Component1 {} .Component2 {}").then(t => expect(t).toEqual({ warnings: 0 })));
+  it("Block selector with Element selector should be allowed", () =>
+    createRuleTester.test(rule, ".Component .Component__element {}").then(t =>
+      expect(t).toEqual({
+        warnings: 0
+      })
+    )
+  );
+
+  it("Element selector in Block should be allowed", () =>
+    createRuleTester.test(rule, ".Component { .Component__element {} }").then(t =>
+      expect(t).toEqual({
+        warnings: 0
+      })
+    )
+  );
+
+  it("Two independent blocks should be allowed", () =>
+    createRuleTester.test(rule, ".Component1 {} .Component2 {}").then(t => expect(t).toEqual({ warnings: 0 }))
+  );
 });

--- a/packages/stylelint-config-swissquote/src/rules/__tests__/no-block-inside-block.js
+++ b/packages/stylelint-config-swissquote/src/rules/__tests__/no-block-inside-block.js
@@ -1,0 +1,57 @@
+var createRuleTester = require("../../testUtils/createRuleTester");
+var rule = require("../no-block-inside-block");
+
+describe("tests for no-block-inside-block", () => {
+  it("Any nested Block shouldn't be OK", () =>
+    createRuleTester.test(rule, ".Component1 { .Component2 {} }").then(t =>
+      expect(t).toEqual({
+        warnings: 1,
+        column: 15,
+        line: 1,
+        text: "A block should not depend on another block directly"
+      })
+    ));
+
+  it("Block inside Element of another Block is not allowed", () =>
+    createRuleTester.test(rule, ".Component1 { .Component1__element { .Component2 {}}}").then(t =>
+      expect(t).toEqual({
+        column: 38,
+        line: 1,
+        text: "A block should not depend on another block directly",
+        warnings: 1
+      })
+    ));
+
+  it("Block inside Element with nesting selector of another Block is not allowed", () =>
+    createRuleTester.test(rule, ".Component1 { & .Component1__element { .Component2 {} } }").then(t =>
+      expect(t).toEqual({
+        column: 40,
+        line: 1,
+        text: "A block should not depend on another block directly",
+        warnings: 1
+      })
+    ));
+
+  it("Block selector in subling Element is not allowed", () =>
+    createRuleTester.test(rule, ".Component1 { .Component1__element .Component2 {}}").then(t =>
+      expect(t).toEqual({
+        column: 15,
+        line: 1,
+        text: "A block should not depend on another block directly",
+        warnings: 1
+      })
+    ));
+
+  it("Block selector in child Element is not allowed", () =>
+    createRuleTester.test(rule, ".Component1 { .Component1__element > .Component2 {}}").then(t =>
+      expect(t).toEqual({
+        column: 15,
+        line: 1,
+        text: "A block should not depend on another block directly",
+        warnings: 1
+      })
+    ));
+
+  it("Two independent blocks is allowed", () =>
+    createRuleTester.test(rule, ".Component1 {} .Component2 {}").then(t => expect(t).toEqual({ warnings: 0 })));
+});

--- a/packages/stylelint-config-swissquote/src/rules/no-block-inside-block.js
+++ b/packages/stylelint-config-swissquote/src/rules/no-block-inside-block.js
@@ -1,0 +1,83 @@
+const selectorParser = require("postcss-selector-parser");
+const resolveNestedSelector = require("postcss-resolve-nested-selector");
+const report = require("stylelint/lib/utils/report");
+
+const cssRuleHasSelectorEndingWithColon = require("../utils/cssRuleHasSelectorEndingWithColon");
+
+const ruleName = "swissquote/no-block-inside-block";
+const messages = {
+  rejected: "A block should not depend on another block directly"
+};
+
+const isBlock = /^[A-Z][a-zA-Z0-9]*$/;
+
+function getGroup(selectorNode) {
+    const group = [];
+  
+    // Get all elements after the current one till the next separator
+    let take = false;
+    const length = selectorNode.parent.nodes.length;
+    for (let i = 0; i < length; i++) {
+      if (take) {
+        group.push(selectorNode.parent.nodes[i]);
+      }
+  
+      // When at the current element, start to take
+      if (selectorNode.parent.nodes[i] === selectorNode) {
+        take = true;
+      }
+    }
+ 
+    return group;
+  }
+  
+  function isInsideBlock(selectorNode) {
+    let group;
+    if (selectorNode.parent.parent.type === "pseudo") {
+      group = getGroup(selectorNode.parent.parent);
+    } else {
+      group = getGroup(selectorNode);
+    }
+  
+    // If there is at least one component in the group, we're good
+    return group.some(
+      element => element.type === "class" && element.value.match(isBlock)
+    );
+  }
+
+module.exports = function() {
+    return (root, result) => {
+      root.walkRules(rule => {
+        if (cssRuleHasSelectorEndingWithColon(rule)) {
+          return;
+        }
+        console.log(resolveNestedSelector(rule.selector, rule));
+        resolveNestedSelector(rule.selector, rule).forEach(selector => {
+          selectorParser(selectorAST => {
+            selectorAST.walk(selectorNode => {
+              // No need to check if the current element isn't a Block
+              if (
+                selectorNode.type !== "class" ||
+                !selectorNode.value.match(isBlock)
+              ) {
+                return;
+              }
+  
+              if (isInsideBlock(selectorNode)) {
+                report({
+                  message: messages.rejected,
+                  node: rule,
+                  index: selectorNode.sourceIndex,
+                  ruleName,
+                  result
+                });
+              }
+            });
+          }).process(selector);
+        });
+      });
+    };
+  };
+  
+  module.exports.ruleName = ruleName;
+  module.exports.messages = messages;

--- a/packages/stylelint-config-swissquote/src/rules/no-block-inside-block.js
+++ b/packages/stylelint-config-swissquote/src/rules/no-block-inside-block.js
@@ -51,7 +51,6 @@ module.exports = function() {
         if (cssRuleHasSelectorEndingWithColon(rule)) {
           return;
         }
-        console.log(resolveNestedSelector(rule.selector, rule));
         resolveNestedSelector(rule.selector, rule).forEach(selector => {
           selectorParser(selectorAST => {
             selectorAST.walk(selectorNode => {


### PR DESCRIPTION
Don't allow to put block inside block:
e.g. 
```
.Component1 {
  .Component2 { ... }
}

.Component1 {
  &__element .Component2 {
    ....
  }
}
```