### PR TITLE
Documentation fix

### DIFF
--- a/docs/03_Use_Cases/Compiling_CSS.md
+++ b/docs/03_Use_Cases/Compiling_CSS.md
@@ -47,7 +47,7 @@ Webpack. Allowing you to use `import` from EcmaScript 2015 for your CSS.
 
 ```bash
 cd src/main/frontend
-npm install @swissquote/crafty @swissquote/crafty-preset-postcss @swissquote/crafty-runner-gulp --save
+npm install @swissquote/crafty @swissquote/crafty-preset-postcss @swissquote/crafty-runner-webpack --save
 ```
 
 In your `crafty.config.js` file, you must add the following presets.


### PR DESCRIPTION
I think the documentation is not correct, we shouldn't require the @swissquote/crafty-runner-gulp to build CSS with webpack, but @swissquote/crafty-runner-webpack instead.