### PR TITLE
Update React-preset hot-reload documentation

### DIFF
--- a/packages/crafty-preset-react/README.md
+++ b/packages/crafty-preset-react/README.md
@@ -152,7 +152,7 @@ if (process.env.NODE_ENV === "development") {
 If you're using TypeScript you have one more step to make
 
 ```bash
-node/node node_modules/.bin/typings install dt~webpack-env --global
+npm install --save @types/webpack-env
 ```
 
 [Read more about Hot Module Replacement](https://medium.com/@rajaraodv/webpack-hot-module-replacement-hmr-e756a726a07#.6qqb8241p)


### PR DESCRIPTION
To be able to compile with the hot-reload enabled we have to install the missing `@types/webpack-env` package. Solution found here : https://github.com/vitaliy-bobrov/angular-hot-loader/issues/5