### PR TITLE
Remove .json as a test file extension

### DIFF
--- a/packages/crafty-preset-jest/src/index.js
+++ b/packages/crafty-preset-jest/src/index.js
@@ -46,9 +46,9 @@ function normalizeJestOptions(crafty, input, cli) {
     preset.jest(crafty, options);
   });
 
-  // Support all extensions that can be transformed for test files extensions
+  // Support all extensions that can be transformed for test files extensions, except for json
   if (!options.hasOwnProperty("testRegex")) {
-    const extensions = options.moduleFileExtensions.join("|");
+    const extensions = options.moduleFileExtensions.filter(extension => extension !== 'json').join("|");
     options.testRegex = `(/__tests__/.*|(\\.|/)(test|spec))\\.(${extensions})$`;
   }
 


### PR DESCRIPTION
Actually the plugin uses all of `moduleFileExtensions` to decide if a file type can be considered as a test file.
The problem is that the `json` extension is a `moduleFileExtensions` but should not be considered a test file. Otherwise, using a `.json` file to store data for tests inside a `__test__` directory makes Jest parse it, and Jest doesn't find any test inside it, thus the tests fails (a test file sould contain at least one test).