### PR TITLE
Remove commented code on documentation

### DIFF
--- a/packages/crafty-preset-jest/README.md
+++ b/packages/crafty-preset-jest/README.md
@@ -181,7 +181,6 @@ import App from "./App";
 it("renders welcome message", () => {
   const wrapper = shallow(<App />);
   const welcome = <h2>Welcome to React</h2>;
-  // expect(wrapper.contains(welcome)).to.equal(true);
   expect(wrapper.contains(welcome)).toEqual(true);
 });
 ```


### PR DESCRIPTION
It looks like this commented code in the documentation is deprecated and should be removed