### PR TITLE
Handle .ts files with Jest

### DIFF
--- a/packages/crafty-preset-typescript/src/index.js
+++ b/packages/crafty-preset-typescript/src/index.js
@@ -82,7 +82,7 @@ module.exports = {
   },
   jest(crafty, options) {
     options.moduleDirectories.push(MODULES);
-    options.transform["^.+\\.tsx?$"] = require.resolve(
+    options.transform["^.+\\.(ts|tsx)?$"] = require.resolve(
       "ts-jest/preprocessor.js"
     );
 


### PR DESCRIPTION
The React typescript files (`.tsx`) are correctly handled with Jest, but not the `.ts` files. Add the pure TypeScript files to the Jest react transformer.