### PR TITLE
Fix ts-jest warnings

### DIFF
--- a/packages/crafty-preset-typescript/src/index.js
+++ b/packages/crafty-preset-typescript/src/index.js
@@ -112,7 +112,7 @@ module.exports = {
   jest(crafty, options) {
     options.moduleDirectories.push(MODULES);
     options.transform["^.+\\.tsx?$"] = require.resolve(
-      "ts-jest/preprocessor.js"
+      "ts-jest"
     );
 
     options.moduleFileExtensions.push("ts");


### PR DESCRIPTION
Affected crafty versions: 1.4.0+

Fixes warning from ts-jest:
```
ts-jest[main] (WARN) Replace any occurrences of "ts-jest/dist/preprocessor.js" or  "<rootDir>/node_modules/ts-jest/preprocessor.js" in the 'transform' section of your Jest config with just "ts-jest".
```