### PR TITLE
Fixes inability to work in IE11 with enabled hot reload

### DIFF
--- a/packages/crafty-runner-webpack/src/webpack_utils/webpack_url.js
+++ b/packages/crafty-runner-webpack/src/webpack_utils/webpack_url.js
@@ -4,4 +4,4 @@
 // but this variable corresponds to the url of the current package.
 // This file is here to "patch" this url to be able to request hot reloaded modules from
 // the middleware directly
-__webpack_require__.p = `${__resourceQuery.substr(1)}/`;
+__webpack_require__.p = __resourceQuery.substr(1).concat("/");


### PR DESCRIPTION
IE11- doesn't understand template literals. They must be polyfilled or changed to concatenation of strings.