### PR TITLE
enable serving resources over https if the https flag is set in the w…

### DIFF
--- a/packages/crafty-runner-webpack/src/webpack.js
+++ b/packages/crafty-runner-webpack/src/webpack.js
@@ -156,15 +156,18 @@ module.exports = function(crafty, bundle, webpackPort) {
         .plugin("hot")
         .use(require.resolve("webpack/lib/HotModuleReplacementPlugin"));
 
+      // Support Https flag from webpack dev server
+      // to be able to serve resources over HTTPS
+      const httpProtocol = chain.devServer.https ? "https" : "http";
       chain
         .entry("default")
         .prepend(
           require.resolve("./webpack_utils/webpack_url.js") +
-            `?http://localhost:${webpackPort}`
+          `?${httpProtocol}://localhost:${webpackPort}`
         ) // Patch webpack lookup URL
         .prepend(
           require.resolve("webpack-dev-server/client") +
-            `?http://localhost:${webpackPort}`
+          `?${httpProtocol}://localhost:${webpackPort}`
         ) // WebpackDevServer host and port
         .prepend(require.resolve("webpack/hot/only-dev-server")); // "only" prevents reload on syntax errors
     }

--- a/packages/crafty-runner-webpack/src/webpack.js
+++ b/packages/crafty-runner-webpack/src/webpack.js
@@ -158,7 +158,7 @@ module.exports = function(crafty, bundle, webpackPort) {
 
       // Support Https flag from webpack dev server
       // to be able to serve resources over HTTPS
-      const httpProtocol = chain.devServer.https ? "https" : "http";
+      const httpProtocol = !!bundle.https ? "https" : "http";
       chain
         .entry("default")
         .prepend(
@@ -181,7 +181,8 @@ module.exports = function(crafty, bundle, webpackPort) {
       .contentBase(config.destination)
       .headers({
         "Access-Control-Allow-Origin": "*"
-      });
+      })
+      .https(!!bundle.https);
   }
 
   // If --profile is passed, we create a


### PR DESCRIPTION
Hello,
Is it possible to support https this way in crafty please ?
If the flag https of the webpack config is set to true, the webpack dev server should provide the resources over https instead of http.