### PR TITLE
Misc updates: jest-cli callback -> promise; updateSnapshot flag; propagate test result

### DIFF
--- a/packages/crafty-preset-jest/src/index.js
+++ b/packages/crafty-preset-jest/src/index.js
@@ -97,16 +97,16 @@ module.exports = ${JSON.stringify(content, null, 4)};
       const cliOptions = {
         config: configFile,
         coverage: cli.flags.coverage,
-        watch: cli.flags.watch
+        watch: cli.flags.watch,
+        updateSnapshot: cli.flags.updateSnapshot || cli.flags.u
       };
 
       writeFileSync(configFile, `${JSON.stringify(options, null, 2)}\n`);
 
-      require("jest-cli").runCLI(cliOptions, [configFile], result =>
-        result.numFailedTests || result.numFailedTestSuites
-          ? reject()
-          : resolve()
-      );
+      require("jest-cli")
+        .runCLI(cliOptions, [configFile])
+        .then(result => (result.results.success ? resolve(result) : reject()))
+        .catch(reject);
     });
   }
 };

--- a/packages/crafty/src/commands/testCommand.js
+++ b/packages/crafty/src/commands/testCommand.js
@@ -19,13 +19,13 @@ exports.command = function test(crafty, input, cli) {
 
     let done = 0;
     let failed = false;
-    function finishWhenDone() {
+    function finishWhenDone(taskResult) {
       done += 1;
       if (done === tasks.length) {
         if (failed) {
           reject();
         } else {
-          resolve();
+          resolve(taskResult);
         }
       }
     }


### PR DESCRIPTION
Hello!

PR explanation:

1) `jest-cli` api changed [here](https://github.com/facebook/jest/commit/200b032d170054dc3860f3cd869a94201c54dd19#diff-281a28872bb5a78b747f7cd3d114a0edL50), updated accordingly
2) made possible passing `-u, --updateSnapshot` flags to `crafty test` command
3) propagate `taskResult` in `testCommand`, so, for example, this could be achieved:
```js
crafty.commands.test.command(crafty, input, cli).then((results) => {
  // do stuff with results
});
```