### PR TITLE
fix(preset-jest): add compatibility with Jest v27

### DIFF
--- a/packages/crafty-preset-jest/src/esm-transformer.js
+++ b/packages/crafty-preset-jest/src/esm-transformer.js
@@ -36,7 +36,7 @@ function shouldCompile(code) {
   }
 }
 
-module.exports = {
+const transformer = {
   getCacheKey(fileData, filename, instance) {
     return crypto
       .createHash("md5")
@@ -68,3 +68,7 @@ module.exports = {
     return babel.transform(src, options).code;
   }
 };
+
+transformer.createTransformer = () => transformer;
+
+module.exports = transformer;


### PR DESCRIPTION
Hi there,

[Jest v27](https://github.com/facebook/jest/releases/tag/v27.0.0) has been released. This PR brings compatibility with the new version.