### PR TITLE
Fix rollup-plugin-commonjs order

### DIFF
--- a/packages/crafty-preset-babel/src/index.js
+++ b/packages/crafty-preset-babel/src/index.js
@@ -56,7 +56,7 @@ module.exports = {
 
     rollupConfig.input.plugins.babel = {
       plugin: require("@rollup/plugin-babel"),
-      weight: 20,
+      weight: 80,
       options
     };
   },

--- a/packages/crafty-preset-swc/src/index.js
+++ b/packages/crafty-preset-swc/src/index.js
@@ -39,7 +39,7 @@ module.exports = {
 
     rollupConfig.input.plugins.swc = {
       plugin: require("./rollup-plugin-swc.js"),
-      weight: 20,
+      weight: 80,
       options: getConfigurationRollup(crafty, bundle)
     };
   },

--- a/packages/crafty-preset-typescript/src/index.js
+++ b/packages/crafty-preset-typescript/src/index.js
@@ -44,7 +44,7 @@ module.exports = {
   rollup(crafty, bundle, rollupConfig) {
     rollupConfig.input.plugins.typescript = {
       plugin: require("rollup-plugin-typescript2"),
-      weight: 20,
+      weight: 80,
       options: {
         tsconfigOverride: {
           compilerOptions: {
@@ -67,7 +67,7 @@ module.exports = {
 
     rollupConfig.input.plugins.babelTypeScript = {
       plugin: require("@rollup/plugin-babel"),
-      weight: 30,
+      weight: 85,
       options
     };
   },


### PR DESCRIPTION
The commonjs plugin must come before the transpilers

This will work once https://github.com/rollup/plugins/pull/971 is merged