### PR TITLE
Fixed minimatch_1.default is not a function

### DIFF
--- a/packages/crafty-commons/packages/minimatch.js
+++ b/packages/crafty-commons/packages/minimatch.js
@@ -1,1 +1,17 @@
-module.exports = require("../dist/minimatch/index.js");
+const minimatchModule = require("../dist/minimatch/index.js");
+
+const minimatch =
+	typeof minimatchModule === "function"
+		? minimatchModule
+		: minimatchModule.minimatch;
+
+if (typeof minimatch !== "function") {
+	throw new TypeError("Expected minimatch to export a function");
+}
+
+Object.assign(minimatch, minimatchModule, {
+	default: minimatch,
+	minimatch
+});
+
+module.exports = minimatch;

--- a/packages/integration-fixtures-cjs/.gitignore
+++ b/packages/integration-fixtures-cjs/.gitignore
@@ -1,1 +1,2 @@
 sonar-report.xml
+fixtures/**/tmp-*

--- a/packages/integration/.gitignore
+++ b/packages/integration/.gitignore
@@ -1,1 +1,2 @@
 coverage_tmp
+tmp-*

--- a/packages/integration/__tests__/__snapshots__/crafty-preset-typescript-webpack.js.snap
+++ b/packages/integration/__tests__/__snapshots__/crafty-preset-typescript-webpack.js.snap
@@ -400,3 +400,34 @@ chunk (runtime: default) myBundle.min.js (default) ___ KiB [entry] [rendered]
 ",
 }
 `;
+
+exports[`crafty-preset-typescript-webpack > Starts watch mode with fork checker 1`] = `
+{
+  "status": null,
+  "stdall": "
+[__:__:__] Starting Crafty __version__...
+⬡ aps: Server Listening on: http://localhost:__PORT__
+asset myBundle.min.js ___ KiB [emitted] (name: default)
+  sourceMap myBundle.min.js.map ___ KiB [emitted] [dev] (auxiliary name: default)
+asset someLibrary.myBundle.min.js ___ KiB [emitted] (name: someLibrary)
+  sourceMap someLibrary.myBundle.min.js.map ___ KiB [emitted] [dev] (auxiliary name: someLibrary)
+Entrypoint default ___ KiB (___ KiB) = myBundle.min.js 1 auxiliary asset
+Chunk Group someLibrary ___ KiB (___ KiB) = someLibrary.myBundle.min.js 1 auxiliary asset
+chunk (runtime: default) myBundle.min.js (default) ___ KiB (runtime) ___ KiB (javascript) [entry] [rendered]
+  runtime modules ___ KiB 12 modules
+  dependent modules ___ KiB [dependent] 6 modules
+  cacheable modules ___ KiB
+    ../../../../../node_modules/anypack-plugin-serve/client.js ___ KiB [built] [code generated]
+    ./js/script.ts ___ KiB [built] [code generated]
+chunk (runtime: default) someLibrary.myBundle.min.js (someLibrary) ___ KiB [rendered]
+  ./js/SomeLibrary.ts ___ KiB [built] [code generated]
+
+  Compiled successfully!
+  Δt ____ms
+
+Type-checking in progress...
+No typescript errors found.
+",
+  "timedOut": true,
+}
+`;

--- a/packages/integration/__tests__/__snapshots__/crafty-preset-typescript-webpack.js.snap
+++ b/packages/integration/__tests__/__snapshots__/crafty-preset-typescript-webpack.js.snap
@@ -400,34 +400,3 @@ chunk (runtime: default) myBundle.min.js (default) ___ KiB [entry] [rendered]
 ",
 }
 `;
-
-exports[`crafty-preset-typescript-webpack > Starts watch mode with fork checker 1`] = `
-{
-  "status": null,
-  "stdall": "
-[__:__:__] Starting Crafty __version__...
-⬡ aps: Server Listening on: http://localhost:__PORT__
-asset myBundle.min.js ___ KiB [emitted] (name: default)
-  sourceMap myBundle.min.js.map ___ KiB [emitted] [dev] (auxiliary name: default)
-asset someLibrary.myBundle.min.js ___ KiB [emitted] (name: someLibrary)
-  sourceMap someLibrary.myBundle.min.js.map ___ KiB [emitted] [dev] (auxiliary name: someLibrary)
-Entrypoint default ___ KiB (___ KiB) = myBundle.min.js 1 auxiliary asset
-Chunk Group someLibrary ___ KiB (___ KiB) = someLibrary.myBundle.min.js 1 auxiliary asset
-chunk (runtime: default) myBundle.min.js (default) ___ KiB (runtime) ___ KiB (javascript) [entry] [rendered]
-  runtime modules ___ KiB 12 modules
-  dependent modules ___ KiB [dependent] 6 modules
-  cacheable modules ___ KiB
-    ../../../../../node_modules/anypack-plugin-serve/client.js ___ KiB [built] [code generated]
-    ./js/script.ts ___ KiB [built] [code generated]
-chunk (runtime: default) someLibrary.myBundle.min.js (someLibrary) ___ KiB [rendered]
-  ./js/SomeLibrary.ts ___ KiB [built] [code generated]
-
-  Compiled successfully!
-  Δt ____ms
-
-Type-checking in progress...
-No typescript errors found.
-",
-  "timedOut": true,
-}
-`;

--- a/packages/integration/__tests__/crafty-preset-typescript-webpack.js
+++ b/packages/integration/__tests__/crafty-preset-typescript-webpack.js
@@ -142,23 +142,7 @@ describe("crafty-preset-typescript-webpack", () => {
     ).toMatchSnapshot();
   });
 
-  test("Starts watch mode with fork checker", async () => {
-    const cwd = await testUtils.getCleanFixtures(
-      "crafty-preset-typescript-webpack/compiles-forked"
-    );
-
-    const result = await testUtils.runWatch(["watch"], cwd, {
-      timeout: 15000
-    });
-
-    expect(result).toMatchSnapshot();
-    expect(result.status).toBeNull();
-    expect(result.timedOut).toBeTruthy();
-    expect(result.stdall).toContain("Compiled successfully!");
-    expect(result.stdall).not.toMatch(unexpectedErrorPattern);
-  });
-
-  test("Rebuilds in watch mode with fork checker", async () => {
+  test("Starts and rebuilds in watch mode with fork checker", async () => {
     const fixture = await testUtils.getIsolatedFixtures(
       "crafty-preset-typescript-webpack/compiles-forked"
     );
@@ -170,6 +154,30 @@ describe("crafty-preset-typescript-webpack", () => {
     let result;
 
     try {
+      const initialOutput = await testUtils.waitFor(async () => {
+        const output = watch.getStdall();
+
+        if (watch.child.exitCode !== null) {
+          throw new Error(
+            `crafty watch exited before the initial watch compilation completed:\n${output}`
+          );
+        }
+
+        if (unexpectedErrorPattern.test(output)) {
+          throw new Error(
+            `crafty watch printed an unexpected error during startup:\n${output}`
+          );
+        }
+
+        return output.includes("Compiled successfully!") &&
+          output.includes("No typescript errors found.")
+          ? output
+          : false;
+      }, "the initial watch output");
+
+      expect(initialOutput).toContain("Compiled successfully!");
+      expect(initialOutput).toContain("No typescript errors found.");
+
       const initialChunk = await testUtils.waitFor(async () => {
         if (!testUtils.exists(cwd, outputFile)) {
           return false;
@@ -187,6 +195,12 @@ describe("crafty-preset-typescript-webpack", () => {
       );
 
       const rebuiltChunk = await testUtils.waitFor(async () => {
+        if (watch.child.exitCode !== null) {
+          throw new Error(
+            `crafty watch exited before rebuilding after a source change:\n${watch.getStdall()}`
+          );
+        }
+
         const chunk = testUtils.readForSnapshot(cwd, outputFile);
         return chunk.includes("return a + b + 1;") ? chunk : false;
       }, "the rebuilt watch bundle");
@@ -205,6 +219,9 @@ describe("crafty-preset-typescript-webpack", () => {
     }
 
     expect(result.status).toBeNull();
+    expect(result.stdall).toContain("Compiled successfully!");
+    expect(result.stdall).toContain("No typescript errors found.");
+    expect(result.stdall).not.toMatch(unexpectedErrorPattern);
   });
 
   test("Compiles TypeScript - custom paths", async () => {

--- a/packages/integration/__tests__/crafty-preset-typescript-webpack.js
+++ b/packages/integration/__tests__/crafty-preset-typescript-webpack.js
@@ -170,17 +170,14 @@ describe("crafty-preset-typescript-webpack", () => {
     let result;
 
     try {
-      const initialChunk = await testUtils.waitFor(
-        async () => {
-          if (!testUtils.exists(cwd, outputFile)) {
-            return false;
-          }
+      const initialChunk = await testUtils.waitFor(async () => {
+        if (!testUtils.exists(cwd, outputFile)) {
+          return false;
+        }
 
-          const chunk = testUtils.readForSnapshot(cwd, outputFile);
-          return chunk.includes("return a + b;") ? chunk : false;
-        },
-        "the initial watch build"
-      );
+        const chunk = testUtils.readForSnapshot(cwd, outputFile);
+        return chunk.includes("return a + b;") ? chunk : false;
+      }, "the initial watch build");
 
       expect(initialChunk).toContain("return a + b;");
 
@@ -189,13 +186,10 @@ describe("crafty-preset-typescript-webpack", () => {
         originalSource.replace("return a + b;", "return a + b + 1;")
       );
 
-      const rebuiltChunk = await testUtils.waitFor(
-        async () => {
-          const chunk = testUtils.readForSnapshot(cwd, outputFile);
-          return chunk.includes("return a + b + 1;") ? chunk : false;
-        },
-        "the rebuilt watch bundle"
-      );
+      const rebuiltChunk = await testUtils.waitFor(async () => {
+        const chunk = testUtils.readForSnapshot(cwd, outputFile);
+        return chunk.includes("return a + b + 1;") ? chunk : false;
+      }, "the rebuilt watch bundle");
 
       expect(rebuiltChunk).toContain("return a + b + 1;");
       expect(rebuiltChunk).not.toEqual(initialChunk);

--- a/packages/integration/__tests__/crafty-preset-typescript-webpack.js
+++ b/packages/integration/__tests__/crafty-preset-typescript-webpack.js
@@ -5,6 +5,7 @@ import configuration from "@swissquote/crafty/src/configuration";
 import * as testUtils from "../utils";
 
 const getCrafty = configuration.getCrafty;
+const unexpectedErrorPattern = /\b[A-Z][A-Za-z]*Error\b|Error:/;
 
 describe("crafty-preset-typescript-webpack", () => {
   test("Loads crafty-preset-typescript and does not register webpack tasks", async () => {
@@ -139,6 +140,77 @@ describe("crafty-preset-typescript-webpack", () => {
     expect(
       testUtils.readForSnapshot(cwd, "dist/js/someLibrary.myBundle.min.js")
     ).toMatchSnapshot();
+  });
+
+  test("Starts watch mode with fork checker", async () => {
+    const cwd = await testUtils.getCleanFixtures(
+      "crafty-preset-typescript-webpack/compiles-forked"
+    );
+
+    const result = await testUtils.runWatch(["watch"], cwd, {
+      timeout: 15000
+    });
+
+    expect(result).toMatchSnapshot();
+    expect(result.status).toBeNull();
+    expect(result.timedOut).toBeTruthy();
+    expect(result.stdall).toContain("Compiled successfully!");
+    expect(result.stdall).not.toMatch(unexpectedErrorPattern);
+  });
+
+  test("Rebuilds in watch mode with fork checker", async () => {
+    const fixture = await testUtils.getIsolatedFixtures(
+      "crafty-preset-typescript-webpack/compiles-forked"
+    );
+    const cwd = fixture.cwd;
+    const watch = testUtils.startWatch(["watch"], cwd);
+    const outputFile = "dist/js/someLibrary.myBundle.min.js";
+    const someLibraryPath = path.join(cwd, "js", "SomeLibrary.ts");
+    const originalSource = await fs.promises.readFile(someLibraryPath, "utf8");
+    let result;
+
+    try {
+      const initialChunk = await testUtils.waitFor(
+        async () => {
+          if (!testUtils.exists(cwd, outputFile)) {
+            return false;
+          }
+
+          const chunk = testUtils.readForSnapshot(cwd, outputFile);
+          return chunk.includes("return a + b;") ? chunk : false;
+        },
+        "the initial watch build"
+      );
+
+      expect(initialChunk).toContain("return a + b;");
+
+      await fs.promises.writeFile(
+        someLibraryPath,
+        originalSource.replace("return a + b;", "return a + b + 1;")
+      );
+
+      const rebuiltChunk = await testUtils.waitFor(
+        async () => {
+          const chunk = testUtils.readForSnapshot(cwd, outputFile);
+          return chunk.includes("return a + b + 1;") ? chunk : false;
+        },
+        "the rebuilt watch bundle"
+      );
+
+      expect(rebuiltChunk).toContain("return a + b + 1;");
+      expect(rebuiltChunk).not.toEqual(initialChunk);
+      result = await watch.stop();
+    } finally {
+      await fs.promises.writeFile(someLibraryPath, originalSource);
+
+      if (!result) {
+        result = await watch.stop();
+      }
+
+      await fixture.cleanup();
+    }
+
+    expect(result.status).toBeNull();
   });
 
   test("Compiles TypeScript - custom paths", async () => {

--- a/packages/integration/utils.js
+++ b/packages/integration/utils.js
@@ -23,10 +23,6 @@ function getWatchOutput(chunks) {
   return chunks.length === 0 ? "" : Buffer.concat(chunks).toString("utf8");
 }
 
-function normalizeOutput(output) {
-  return output ? `\n${snapshotizeOutput(output)}\n` : "";
-}
-
 function appendStreamChunks(chunks, stream) {
   if (!stream) {
     return;
@@ -35,31 +31,6 @@ function appendStreamChunks(chunks, stream) {
   stream.on("data", chunk => {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   });
-}
-
-function createWatchHandle(child, chunks, exitPromise) {
-  return {
-    child,
-    getStdall() {
-      return normalizeOutput(getWatchOutput(chunks));
-    },
-    async stop(signal = "SIGTERM") {
-      if (child.exitCode === null && !child.killed) {
-        child.kill(signal);
-      }
-
-      const result = await exitPromise;
-
-      return {
-        status: result.exitCode ?? null,
-        // Prefer execa's final aggregated output once the process exits; the
-        // live chunks are only a fallback for interrupted watch sessions.
-        stdall: result.all ? normalizeOutput(result.all.toString("utf8")) : this.getStdall(),
-        timedOut: Boolean(result.timedOut),
-        isCanceled: Boolean(result.isCanceled)
-      };
-    }
-  };
 }
 
 export function snapshotizeOutput(ret) {
@@ -151,6 +122,37 @@ export function snapshotizeOutput(ret) {
     .replace(/[\t\f\v ]+$/gm, "") // Remove spaces at EOL
     .replace(/\.\/([A-Za-z\/\.]*)\n\n__PATH__/gm, `./$1\n__PATH__`) // Sometimes lint output has more line breaks for no known reason ...
     .replace(/\n\n\n+/g, "\n\n"); // Replace multi line breaks by single one
+}
+
+function normalizeOutput(output) {
+  return output ? `\n${snapshotizeOutput(output)}\n` : "";
+}
+
+function createWatchHandle(child, chunks, exitPromise) {
+  return {
+    child,
+    getStdall() {
+      return normalizeOutput(getWatchOutput(chunks));
+    },
+    async stop(signal = "SIGTERM") {
+      if (child.exitCode === null && !child.killed) {
+        child.kill(signal);
+      }
+
+      const result = await exitPromise;
+
+      return {
+        status: result.exitCode ?? null,
+        // Prefer execa's final aggregated output once the process exits; the
+        // live chunks are only a fallback for interrupted watch sessions.
+        stdall: result.all
+          ? normalizeOutput(result.all.toString("utf8"))
+          : this.getStdall(),
+        timedOut: Boolean(result.timedOut),
+        isCanceled: Boolean(result.isCanceled)
+      };
+    }
+  };
 }
 
 export function snapshotizeCSS(ret) {

--- a/packages/integration/utils.js
+++ b/packages/integration/utils.js
@@ -226,33 +226,6 @@ export function startWatch(args, cwd, commandOptions) {
   return createWatchHandle(child, chunks, exitPromise);
 }
 
-export async function runWatch(args, cwd, commandOptions) {
-  const options = getCraftyOptions(cwd, {
-    timeout: 20000,
-    ...commandOptions
-  });
-
-  try {
-    const ret = await execaNode(craftyBin, args, options);
-
-    return {
-      status: ret.exitCode ?? null,
-      stdall: ret.all ? normalizeOutput(ret.all.toString("utf8")) : "",
-      timedOut: Boolean(ret.timedOut)
-    };
-  } catch (error) {
-    if (!error.timedOut) {
-      throw error;
-    }
-
-    return {
-      status: error.exitCode ?? null,
-      stdall: error.all ? normalizeOutput(error.all.toString("utf8")) : "",
-      timedOut: true
-    };
-  }
-}
-
 export function readFile(cwd, file) {
   return fs.readFileSync(path.join(cwd, file)).toString("utf8");
 }

--- a/packages/integration/utils.js
+++ b/packages/integration/utils.js
@@ -4,6 +4,63 @@ import fs from "node:fs";
 import { fileURLToPath } from "url";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const craftyBin = require.resolve("@swissquote/crafty/src/bin.cjs");
+
+function getCraftyOptions(cwd, commandOptions) {
+  const options = {
+    cwd,
+    reject: false,
+    all: true,
+    ...commandOptions
+  };
+
+  options.env = { TESTING_CRAFTY: "true", ...options.env };
+
+  return options;
+}
+
+function getWatchOutput(chunks) {
+  return chunks.length === 0 ? "" : Buffer.concat(chunks).toString("utf8");
+}
+
+function normalizeOutput(output) {
+  return output ? `\n${snapshotizeOutput(output)}\n` : "";
+}
+
+function appendStreamChunks(chunks, stream) {
+  if (!stream) {
+    return;
+  }
+
+  stream.on("data", chunk => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+}
+
+function createWatchHandle(child, chunks, exitPromise) {
+  return {
+    child,
+    getStdall() {
+      return normalizeOutput(getWatchOutput(chunks));
+    },
+    async stop(signal = "SIGTERM") {
+      if (child.exitCode === null && !child.killed) {
+        child.kill(signal);
+      }
+
+      const result = await exitPromise;
+
+      return {
+        status: result.exitCode ?? null,
+        // Prefer execa's final aggregated output once the process exits; the
+        // live chunks are only a fallback for interrupted watch sessions.
+        stdall: result.all ? normalizeOutput(result.all.toString("utf8")) : this.getStdall(),
+        timedOut: Boolean(result.timedOut),
+        isCanceled: Boolean(result.isCanceled)
+      };
+    }
+  };
+}
 
 export function snapshotizeOutput(ret) {
   const escapedPath = path
@@ -59,6 +116,7 @@ export function snapshotizeOutput(ret) {
       /Starting Crafty ([0-9]+\.[0-9]+\.[0-9]+)/g,
       "Starting Crafty __version__"
     ) // Remove version information in crafty output
+    .replace(/(https?:\/\/localhost:)\d+/gm, "$1__PORT__") // Watch mode picks the first free port in a range
     .replace(/^(\s*)PASS(\s*)/gm, "PASS ") // Fix weird space in some case with nested jest runs (Jest)
     .replace(/^(\s*)FAIL(\s*)/gm, "FAIL ") // Fix weird space in some case with nested jest runs (Jest)
     .replace(
@@ -100,25 +158,97 @@ export function snapshotizeCSS(ret) {
 }
 
 export async function run(args, cwd, commandOptions) {
-  const options = {
-    cwd,
-    reject: false,
-    all: true,
-    ...commandOptions
-  };
+  const options = getCraftyOptions(cwd, commandOptions);
 
-  options.env = { TESTING_CRAFTY: "true", ...options.env };
-
-  const ret = await execaNode(
-    require.resolve("@swissquote/crafty/src/bin.cjs"),
-    args,
-    options
-  );
+  const ret = await execaNode(craftyBin, args, options);
 
   return {
     status: ret.exitCode,
-    stdall: ret.all ? `\n${snapshotizeOutput(ret.all.toString("utf8"))}\n` : ""
+    stdall: ret.all ? normalizeOutput(ret.all.toString("utf8")) : ""
   };
+}
+
+export async function getIsolatedFixtures(fixtures, clean = ["dist"]) {
+  const sourceDir = path.join(
+    __dirname,
+    "..",
+    "integration-fixtures-cjs",
+    "fixtures",
+    fixtures
+  );
+  // Keep the temp copy next to the original fixture so relative layout
+  // assumptions made by watch-mode builds still match the tracked fixture.
+  const tmpDir = await fs.promises.mkdtemp(
+    path.join(path.dirname(sourceDir), "tmp-")
+  );
+
+  await fs.promises.cp(sourceDir, tmpDir, { recursive: true });
+
+  for (const dirToClean of clean) {
+    // eslint-disable-next-line no-await-in-loop
+    await fs.promises.rm(path.join(tmpDir, dirToClean), {
+      force: true,
+      recursive: true
+    });
+  }
+
+  return {
+    cwd: tmpDir,
+    async cleanup() {
+      await fs.promises.rm(tmpDir, {
+        force: true,
+        recursive: true
+      });
+    }
+  };
+}
+
+export function startWatch(args, cwd, commandOptions) {
+  const options = getCraftyOptions(cwd, commandOptions);
+  const child = execaNode(craftyBin, args, options);
+  const chunks = [];
+
+  // Execa's final `all` output is easiest to consume after exit, so keep a
+  // live fallback while the long-running watch process is still active.
+  appendStreamChunks(chunks, child.stdout);
+  appendStreamChunks(chunks, child.stderr);
+
+  const exitPromise = child.catch(error => {
+    if (error.isCanceled || error.timedOut) {
+      return error;
+    }
+
+    throw error;
+  });
+
+  return createWatchHandle(child, chunks, exitPromise);
+}
+
+export async function runWatch(args, cwd, commandOptions) {
+  const options = getCraftyOptions(cwd, {
+    timeout: 20000,
+    ...commandOptions
+  });
+
+  try {
+    const ret = await execaNode(craftyBin, args, options);
+
+    return {
+      status: ret.exitCode ?? null,
+      stdall: ret.all ? normalizeOutput(ret.all.toString("utf8")) : "",
+      timedOut: Boolean(ret.timedOut)
+    };
+  } catch (error) {
+    if (!error.timedOut) {
+      throw error;
+    }
+
+    return {
+      status: error.exitCode ?? null,
+      stdall: error.all ? normalizeOutput(error.all.toString("utf8")) : "",
+      timedOut: true
+    };
+  }
 }
 
 export function readFile(cwd, file) {
@@ -131,6 +261,28 @@ export function exists(cwd, file) {
 
 export function readForSnapshot(cwd, file) {
   return snapshotizeOutput(readFile(cwd, file));
+}
+
+export async function waitFor(check, description, timeout = 30000) {
+  const endTime = Date.now() + timeout;
+
+  // Watch-mode assertions are driven by emitted files changing over time, not
+  // by the process exiting, so a small polling helper keeps those tests simple.
+  while (Date.now() < endTime) {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await check();
+
+    if (result) {
+      return result;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise(resolve => {
+      setTimeout(resolve, 100);
+    });
+  }
+
+  throw new Error(`Timed out waiting for ${description}`);
 }
 
 export async function getCleanFixtures(fixtures, clean = ["dist"]) {


### PR DESCRIPTION
Fix for https://github.com/swissquote/crafty/issues/3133

This PR fixes `crafty watch` for the TypeScript webpack + fork-checker path and adds integration coverage for the watch flow.

It updates the minimatch wrapper so bundled consumers can use it as a callable default export again, which resolves the watch-mode crash. It also adds watch-mode integration coverage for both startup and rebuild behavior, stabilizes watch snapshots by normalizing dynamic localhost ports, and ignores temporary fixture copies created by the new watch tests so they do not leak into Source Control.