### PR TITLE
Add some watch tests and fix watch for postcss

### DIFF
--- a/packages/crafty-runner-gulp/package.json
+++ b/packages/crafty-runner-gulp/package.json
@@ -21,7 +21,7 @@
     "@swissquote/crafty-commons-gulp": "1.29.0"
   },
   "devDependencies": {
-    "@onigoetz/stream-plumber": "1.1.1",
+    "@onigoetz/stream-plumber": "1.2.0",
     "pump": "3.0.4",
     "vinyl-fs": "4.0.2"
   },

--- a/packages/crafty-runner-gulp/src/StreamHandler.js
+++ b/packages/crafty-runner-gulp/src/StreamHandler.js
@@ -38,17 +38,23 @@ module.exports = class StreamHandler {
     const sourceStream = gulp.src(this.source, this.srcOptions);
     const destStream = gulp.dest(this.destination, this.destOptions);
 
-    return pump(sourceStream, ...this.handlers, destStream, err => {
-      // Display the error if there is any
-      if (err) {
-        crafty.error(err);
-      }
+    return pump(
+      sourceStream,
+      ...this.handlers,
+      plumber.stop(),
+      destStream,
+      err => {
+        // Display the error if there is any
+        if (err) {
+          crafty.error(err);
+        }
 
-      // Signal completion
-      if (this.callback) {
-        this.callback(err);
+        // Signal completion
+        if (this.callback) {
+          this.callback(err);
+        }
       }
-    });
+    );
   }
 };
 

--- a/packages/crafty-runner-gulp/src/StreamHandler.js
+++ b/packages/crafty-runner-gulp/src/StreamHandler.js
@@ -38,23 +38,17 @@ module.exports = class StreamHandler {
     const sourceStream = gulp.src(this.source, this.srcOptions);
     const destStream = gulp.dest(this.destination, this.destOptions);
 
-    return pump(
-      sourceStream,
-      ...this.handlers,
-      plumber.stop(),
-      destStream,
-      err => {
-        // Display the error if there is any
-        if (err) {
-          crafty.error(err);
-        }
-
-        // Signal completion
-        if (this.callback) {
-          this.callback(err);
-        }
+    return pump(sourceStream, ...this.handlers, destStream, err => {
+      // Display the error if there is any
+      if (err) {
+        crafty.error(err);
       }
-    );
+
+      // Signal completion
+      if (this.callback) {
+        this.callback(err);
+      }
+    });
   }
 };
 

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-postcss-gulp/compiles-watch/crafty.config.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-postcss-gulp/compiles-watch/crafty.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  presets: ["@swissquote/crafty-preset-postcss", "@swissquote/crafty-runner-gulp"],
+  css: {
+    myBundle: {
+      source: "css/style.scss",
+      watch: ["css/**"]
+    }
+  }
+};

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-postcss-gulp/compiles-watch/css/imported.scss
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-postcss-gulp/compiles-watch/css/imported.scss
@@ -1,0 +1,3 @@
+.Link {
+    color: blue;
+}

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-postcss-gulp/compiles-watch/css/style.scss
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-postcss-gulp/compiles-watch/css/style.scss
@@ -1,0 +1,5 @@
+@import "imported.scss";
+
+.Component {
+    margin: 0;
+}

--- a/packages/integration-fixtures-cjs/fixtures/crafty-runner-webpack/compiles-watch/crafty.config.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-runner-webpack/compiles-watch/crafty.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  presets: ["@swissquote/crafty-runner-webpack"],
+  destination_js: "dist/js",
+  js: {
+    myBundle: {
+      source: "js/script.js"
+    }
+  }
+};

--- a/packages/integration-fixtures-cjs/fixtures/crafty-runner-webpack/compiles-watch/js/SomeLibrary.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-runner-webpack/compiles-watch/js/SomeLibrary.js
@@ -1,0 +1,3 @@
+export function getMessage() {
+  return "hello";
+}

--- a/packages/integration-fixtures-cjs/fixtures/crafty-runner-webpack/compiles-watch/js/script.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-runner-webpack/compiles-watch/js/script.js
@@ -1,0 +1,2 @@
+import { getMessage } from "./SomeLibrary";
+console.log(getMessage());

--- a/packages/integration/__tests__/crafty-preset-postcss-gulp.js
+++ b/packages/integration/__tests__/crafty-preset-postcss-gulp.js
@@ -1,4 +1,6 @@
 import { test, expect } from "vitest";
+import fs from "fs";
+import path from "path";
 import configuration from "@swissquote/crafty/src/configuration";
 import getCommands from "@swissquote/crafty/src/commands/index.js";
 
@@ -185,4 +187,66 @@ test("Compiles CSS, compiles color-function", async () => {
     ":root{--color-default:#d1d1d1;--color-light:var(--color-default)}.Button{color:#fafafa;background-color:var(--color-light)}" +
       "/*# sourceMappingURL=myBundle.min.css.map */\n"
   );
+});
+
+test("Starts and rebuilds in watch mode", async () => {
+  const fixture = await testUtils.getIsolatedFixtures(
+    "crafty-preset-postcss-gulp/compiles-watch"
+  );
+  const cwd = fixture.cwd;
+  const watch = testUtils.startWatch(["watch"], cwd);
+  const outputFile = "dist/css/myBundle.min.css";
+  const importedPath = path.join(cwd, "css", "imported.scss");
+  const originalSource = await fs.promises.readFile(importedPath, "utf8");
+  let result;
+
+  try {
+    const initialOutput = await testUtils.waitFor(async () => {
+      const output = watch.getStdall();
+
+      if (watch.child.exitCode !== null) {
+        throw new Error(
+          `crafty watch exited before the initial compilation completed:\n${output}`
+        );
+      }
+
+      return output.includes("Finished 'css_myBundle'") ? output : false;
+    }, "the initial watch output");
+
+    expect(initialOutput).toContain("Finished 'css_myBundle'");
+
+    const initialCSS = await testUtils.waitFor(async () => {
+      if (!testUtils.exists(cwd, outputFile)) return false;
+      const css = testUtils.readFile(cwd, outputFile);
+      return css.includes("color: #00f") ? css : false;
+    }, "the initial watch build");
+
+    expect(initialCSS).toContain("color: #00f");
+
+    await fs.promises.writeFile(
+      importedPath,
+      originalSource.replace("color: blue", "color: red")
+    );
+
+    const rebuiltCSS = await testUtils.waitFor(async () => {
+      if (watch.child.exitCode !== null) {
+        throw new Error(
+          `crafty watch exited before rebuilding after a source change:\n${watch.getStdall()}`
+        );
+      }
+      const css = testUtils.readFile(cwd, outputFile);
+      return css.includes("color: red") ? css : false;
+    }, "the rebuilt watch CSS");
+
+    expect(rebuiltCSS).toContain("color: red");
+    expect(rebuiltCSS).not.toEqual(initialCSS);
+    result = await watch.stop();
+  } finally {
+    await fs.promises.writeFile(importedPath, originalSource);
+    if (!result) result = await watch.stop();
+    await fixture.cleanup();
+  }
+
+  expect(result.status).toBeNull();
+  expect(result.stdall).toContain("Finished 'css_myBundle'");
 });

--- a/packages/integration/__tests__/crafty-runner-webpack.js
+++ b/packages/integration/__tests__/crafty-runner-webpack.js
@@ -1,5 +1,9 @@
 import { describe, test, expect } from "vitest";
+import fs from "fs";
+import path from "path";
 import * as testUtils from "../utils";
+
+const unexpectedErrorPattern = /Error(?!.*ExperimentalWarning)/;
 
 describe("crafty-runner-webpack", () => {
   test("Compiles Only with Webpack", async () => {
@@ -40,5 +44,74 @@ describe("crafty-runner-webpack", () => {
 
     expect(testUtils.exists(cwd, "dist/js/myBundle.min.js")).toBeFalsy();
     expect(testUtils.exists(cwd, "dist/js/myBundle.min.js.map")).toBeFalsy();
+  });
+
+  test("Starts and rebuilds in watch mode", async () => {
+    const fixture = await testUtils.getIsolatedFixtures(
+      "crafty-runner-webpack/compiles-watch"
+    );
+    const cwd = fixture.cwd;
+    const watch = testUtils.startWatch(["watch"], cwd);
+    const outputFile = "dist/js/myBundle.min.js";
+    const someLibraryPath = path.join(cwd, "js", "SomeLibrary.js");
+    const originalSource = await fs.promises.readFile(someLibraryPath, "utf8");
+    let result;
+
+    try {
+      const initialOutput = await testUtils.waitFor(async () => {
+        const output = watch.getStdall();
+
+        if (watch.child.exitCode !== null) {
+          throw new Error(
+            `crafty watch exited before the initial compilation completed:\n${output}`
+          );
+        }
+
+        if (unexpectedErrorPattern.test(output)) {
+          throw new Error(
+            `crafty watch printed an unexpected error during startup:\n${output}`
+          );
+        }
+
+        return output.includes("Compiled successfully!") ? output : false;
+      }, "the initial watch output");
+
+      expect(initialOutput).toContain("Compiled successfully!");
+
+      const initialChunk = await testUtils.waitFor(async () => {
+        if (!testUtils.exists(cwd, outputFile)) return false;
+        const chunk = testUtils.readForSnapshot(cwd, outputFile);
+        return chunk.includes('"hello"') ? chunk : false;
+      }, "the initial watch build");
+
+      expect(initialChunk).toContain('"hello"');
+
+      await fs.promises.writeFile(
+        someLibraryPath,
+        originalSource.replace('"hello"', '"world"')
+      );
+
+      const rebuiltChunk = await testUtils.waitFor(async () => {
+        if (watch.child.exitCode !== null) {
+          throw new Error(
+            `crafty watch exited before rebuilding after a source change:\n${watch.getStdall()}`
+          );
+        }
+        const chunk = testUtils.readForSnapshot(cwd, outputFile);
+        return chunk.includes('"world"') ? chunk : false;
+      }, "the rebuilt watch bundle");
+
+      expect(rebuiltChunk).toContain('"world"');
+      expect(rebuiltChunk).not.toEqual(initialChunk);
+      result = await watch.stop();
+    } finally {
+      await fs.promises.writeFile(someLibraryPath, originalSource);
+      if (!result) result = await watch.stop();
+      await fixture.cleanup();
+    }
+
+    expect(result.status).toBeNull();
+    expect(result.stdall).toContain("Compiled successfully!");
+    expect(result.stdall).not.toMatch(unexpectedErrorPattern);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2896,10 +2896,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@onigoetz/stream-plumber@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@onigoetz/stream-plumber@npm:1.1.1"
-  checksum: 10c0/b81b7840bd773118097f67f21a123f8b4ecd73875a6da46ad83e7ffba87374f906e263333a69383338e7c42a4381e88d4c701709a521f29381d72ee90ea3fe0b
+"@onigoetz/stream-plumber@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@onigoetz/stream-plumber@npm:1.2.0"
+  checksum: 10c0/d4f48d2fc798c5c761c2c866e1d771ba1a70b73409fcb2a26b560884669034e724621c3e116950d9106aba6f71339071c72052cdc74098a08fd7580ea0ee50c8
   languageName: node
   linkType: hard
 
@@ -4106,7 +4106,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@swissquote/crafty-runner-gulp@workspace:packages/crafty-runner-gulp"
   dependencies:
-    "@onigoetz/stream-plumber": "npm:1.1.1"
+    "@onigoetz/stream-plumber": "npm:1.2.0"
     "@swissquote/crafty": "npm:1.29.0"
     "@swissquote/crafty-commons": "npm:1.29.0"
     "@swissquote/crafty-commons-gulp": "npm:1.29.0"


### PR DESCRIPTION
## Problem

Running `crafty watch` with `crafty-preset-postcss` + `crafty-runner-gulp` crashed immediately with:

```
[15:17:06] stream.push() after EOF
[15:17:06] An error occured while running tasks {
  name: 'css_myBundle',
  error: Error: stream.push() after EOF
      at Composer.<anonymous> (@onigoetz/stream-plumber/index.js:60)
      at ReadableState.drain (streamx/index.js:378)
```

## Root Cause and fix

https://github.com/onigoetz/stream-plumber/pull/93

## Test

Added a new integration test **"Starts and rebuilds in watch mode"** for the `crafty-preset-postcss` + `crafty-runner-gulp` combination with a matching fixture under `packages/integration-fixtures-cjs/fixtures/crafty-preset-postcss-gulp/compiles-watch/`. The test:

1. Starts `crafty watch`
2. Waits for the initial compilation to complete and verifies the CSS output contains `color: #00f`
3. Modifies a source SCSS file (`imported.scss`: `color: blue` → `color: red`)
4. Waits for the rebuild and verifies the CSS output now contains `color: red`
5. Stops the watcher and confirms it exited cleanly

Note: the content assertions use unminified CSS values (`color: #00f` with space) because watch mode runs in development mode, which does not minify output.

## Files Changed

- `packages/crafty-runner-gulp/src/StreamHandler.js` — add `plumber.stop()` before `destStream` in `generate()`
- `packages/integration/__tests__/crafty-preset-postcss-gulp.js` — add watch mode integration test
- `packages/integration-fixtures-cjs/fixtures/crafty-preset-postcss-gulp/compiles-watch/` — new fixture (config + SCSS source files)

