### PR TITLE
fix(crafty-preset-stylelint): declare resolve-from as a runtime dependency

### DIFF
--- a/packages/crafty-preset-stylelint/package.json
+++ b/packages/crafty-preset-stylelint/package.json
@@ -23,12 +23,12 @@
     "@swissquote/crafty-preset-prettier": "1.30.0",
     "@swissquote/stylelint-config-swissquote": "1.30.0",
     "postcss": "8.5.15",
-    "postcss-scss": "4.0.9"
+    "postcss-scss": "4.0.9",
+    "resolve-from": "5.0.0"
   },
   "devDependencies": {
     "gulp-stylelint-esm": "3.0.0",
     "is-plain-object": "5.0.0",
-    "resolve-from": "5.0.0",
     "stylelint": "17.8.0",
     "stylelint-sarif-formatter": "1.0.7"
   },


### PR DESCRIPTION
## Problem

`crafty-preset-stylelint` imports `resolve-from` and **uses it at lint time** in `src/commands/lint_css.js`:

```js
import resolveFrom from "resolve-from";
// ...
configuration = require(resolveFrom.silent(process.cwd(), configFile) || ...);
```

…but `resolve-from` was declared only under **`devDependencies`**. devDependencies are not installed for consumers, so this import only resolved when `resolve-from` happened to be hoisted into the consumer's `node_modules` via some *other* transitive dependency.

When the dependency tree stops providing it, `crafty cssLint` crashes at runtime:

```
Cannot find package 'resolve-from' imported from
  …/@swissquote/crafty-preset-stylelint/src/commands/lint_css.js
```

## How it surfaced

A consumer ran a Renovate "all non-major" update (`@swissquote/crafty*` 1.29.0 → 1.30.0 plus other minor/patch bumps). The bump removed the last transitive consumer of `resolve-from@^4`, so it disappeared from the lockfile entirely. The next CSS lint then failed with `ERR_MODULE_NOT_FOUND` — surfaced by the Swissquote DGL-5 pre-commit hook as a misleading *"Stylelint errors, changes rejected"*.

The latent defect is present in 1.29.0 too; it was simply masked by hoisting.

## Fix

Move `resolve-from` (already pinned at `5.0.0`) from `devDependencies` to `dependencies`.

- **`yarn.lock` is unchanged** — the `resolve-from@npm:5.0.0` descriptor was already resolved, so `yarn install --immutable` stays clean (verified locally).
- Scope is intentionally minimal. `crafty-preset-eslint` keeps a similar `resolve-from` devDependency, but its runtime code uses a **vendored** copy (`require("../packages/resolve-from")`), so it is unaffected and left untouched.
