### PR TITLE
React Compiler

### DIFF
--- a/packages/crafty-preset-react/README.md
+++ b/packages/crafty-preset-react/README.md
@@ -54,6 +54,79 @@ module.exports = {
 };
 ```
 
+## React Compiler
+
+> This feature works with the **SWC** preset on Webpack, Rspack and Gulp.
+
+The [React Compiler](https://react.dev/learn/react-compiler) automatically
+memoizes your components and hooks at build time, removing most of the need for
+manual `useMemo`, `useCallback` and `React.memo`. Crafty enables it through
+SWC's built-in support.
+
+It is **disabled by default** and must be opted into per bundle by setting
+`reactCompiler` on the bundle's `react` option:
+
+```js
+module.exports = {
+  presets: [
+    "@swissquote/crafty-preset-swc",
+    "@swissquote/crafty-runner-webpack",
+    "@swissquote/crafty-preset-react",
+  ],
+  js: {
+    app: {
+      source: "js/app.js",
+      react: {
+        reactCompiler: true,
+      },
+    },
+  },
+};
+```
+
+The compiler runs in both development and production builds, and can be combined
+with Fast Refresh:
+
+```js
+react: {
+  refreshMode: "fast",
+  reactCompiler: true,
+}
+```
+
+### Requirements
+
+- The compiler targets **React 19** by default. For React 17 or 18, set the
+  `target` option (see below).
+- With Rspack, the compiler requires `@rspack/core` **2.1.0 or later**.
+
+### Options
+
+Passing `true` uses SWC's defaults. To configure the compiler, pass an object
+instead — the options match the
+[React Compiler configuration](https://react.dev/reference/react-compiler/configuration)
+(for example `target`, `compilationMode`, `panicThreshold`):
+
+```js
+react: {
+  reactCompiler: {
+    target: "18", // "17" | "18" | "19" (default)
+  },
+}
+```
+
+### Disabling it
+
+The React Compiler is off by default, so there is nothing to do to keep it
+disabled. To turn it off for a bundle where it was enabled, remove the
+`reactCompiler` key or set it to `false`:
+
+```js
+react: {
+  reactCompiler: false,
+}
+```
+
 ## Hot Module Replacement
 
 When doing modern JavaScript development, the usual process is **Write code**,

--- a/packages/crafty-preset-react/index.js
+++ b/packages/crafty-preset-react/index.js
@@ -63,17 +63,30 @@ module.exports = {
     }
   },
   swc(crafty, bundle, swcOptions) {
-    if (enableFastRefresh(crafty, bundle)) {
+    const reactCompiler = bundle.react && bundle.react.reactCompiler;
+    const fastRefresh = enableFastRefresh(crafty, bundle);
+
+    if (fastRefresh || reactCompiler) {
       if (!swcOptions.jsc.transform) {
         swcOptions.jsc.transform = {};
       }
+    }
 
+    if (fastRefresh) {
       if (!swcOptions.jsc.transform.react) {
         swcOptions.jsc.transform.react = {};
       }
 
       swcOptions.jsc.transform.react.development = true;
       swcOptions.jsc.transform.react.refresh = true;
+    }
+
+    // The React Compiler is opt-in per bundle (`react: { reactCompiler: true }`).
+    // Passing the value through means `true` uses SWC's defaults while an object
+    // forwards options (target, compilationMode, ...) to the compiler.
+    // It runs in both development and production builds.
+    if (reactCompiler) {
+      swcOptions.jsc.transform.reactCompiler = reactCompiler;
     }
   },
   webpack(crafty, bundle, chain) {

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-gulp/react-compiler/crafty.config.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-gulp/react-compiler/crafty.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  presets: [
+    "@swissquote/crafty-preset-swc",
+    "@swissquote/crafty-preset-react",
+    "@swissquote/crafty-runner-gulp"
+  ],
+  js: {
+    myBundle: {
+      source: "js/script.js",
+      react: {
+        reactCompiler: true
+      }
+    }
+  }
+};

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-gulp/react-compiler/js/script.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-gulp/react-compiler/js/script.js
@@ -1,0 +1,17 @@
+// A function component using props so the React Compiler emits memoization
+// (a `react/compiler-runtime` import and `_c(...)` memo-cache calls).
+function Greeting({ name, items }) {
+  return (
+    <div>
+      <h1>Hello {name}</h1>
+      <ul>
+        {items.map(item => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// Export the component so it is kept (and its compiled output emitted).
+export default Greeting;

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-rspack/react-compiler/crafty.config.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-rspack/react-compiler/crafty.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  presets: [
+    "@swissquote/crafty-preset-swc",
+    "@swissquote/crafty-preset-react",
+    "@swissquote/crafty-runner-rspack"
+  ],
+  js: {
+    myBundle: {
+      // Keep React (and the injected `react/compiler-runtime`) external so the
+      // compiler output stays visible in the bundle instead of being inlined.
+      externals: ["react/**"],
+      source: "js/script.js",
+      react: {
+        reactCompiler: true
+      }
+    }
+  }
+};

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-rspack/react-compiler/js/script.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-rspack/react-compiler/js/script.js
@@ -1,0 +1,17 @@
+// A function component using props so the React Compiler emits memoization
+// (a `react/compiler-runtime` import and `_c(...)` memo-cache calls).
+function Greeting({ name, items }) {
+  return (
+    <div>
+      <h1>Hello {name}</h1>
+      <ul>
+        {items.map(item => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// Export the component so it is kept (and its compiled output emitted).
+export default Greeting;

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-webpack/react-compiler-disabled/crafty.config.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-webpack/react-compiler-disabled/crafty.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  presets: [
+    "@swissquote/crafty-preset-swc",
+    "@swissquote/crafty-preset-react",
+    "@swissquote/crafty-runner-webpack"
+  ],
+  js: {
+    myBundle: {
+      externals: ["react/**"],
+      source: "js/script.js",
+      // React preset enabled, but the React Compiler is left off (the default).
+      react: true
+    }
+  }
+};

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-webpack/react-compiler-disabled/js/script.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-webpack/react-compiler-disabled/js/script.js
@@ -1,0 +1,17 @@
+// Same component as the react-compiler fixture, but without opting into the
+// React Compiler, so no `react/compiler-runtime` import should be emitted.
+function Greeting({ name, items }) {
+  return (
+    <div>
+      <h1>Hello {name}</h1>
+      <ul>
+        {items.map(item => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// Export the component so it is kept (and its compiled output emitted).
+export default Greeting;

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-webpack/react-compiler/crafty.config.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-webpack/react-compiler/crafty.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  presets: [
+    "@swissquote/crafty-preset-swc",
+    "@swissquote/crafty-preset-react",
+    "@swissquote/crafty-runner-webpack"
+  ],
+  js: {
+    myBundle: {
+      // Keep React (and the injected `react/compiler-runtime`) external so the
+      // compiler output stays visible in the bundle instead of being inlined.
+      externals: ["react/**"],
+      source: "js/script.js",
+      react: {
+        reactCompiler: true
+      }
+    }
+  }
+};

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-webpack/react-compiler/js/script.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-webpack/react-compiler/js/script.js
@@ -1,0 +1,17 @@
+// A function component using props so the React Compiler emits memoization
+// (a `react/compiler-runtime` import and `_c(...)` memo-cache calls).
+function Greeting({ name, items }) {
+  return (
+    <div>
+      <h1>Hello {name}</h1>
+      <ul>
+        {items.map(item => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// Export the component so it is kept (and its compiled output emitted).
+export default Greeting;

--- a/packages/integration/__tests__/__snapshots__/crafty-preset-swc-gulp.js.snap
+++ b/packages/integration/__tests__/__snapshots__/crafty-preset-swc-gulp.js.snap
@@ -335,6 +335,28 @@ exports[`Compiles JavaScript, new features transpiled 3`] = `
 "
 `;
 
+exports[`Enables the React Compiler 1`] = `
+{
+  "status": 0,
+  "stdall": "
+[__:__:__] Starting Crafty __version__...
+[__:__:__] Files will be stored in:
+            js: __PATH__/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-gulp/react-compiler/dist/js
+[__:__:__] Starting 'default' ...
+[__:__:__] Starting 'js' ...
+[__:__:__] Starting 'js_myBundle' ...
+[__:__:__] Finished 'js_myBundle' after ____ ms
+[__:__:__] Finished 'js' after ____ ms
+[__:__:__] Finished 'default' after ____ ms
+",
+}
+`;
+
+exports[`Enables the React Compiler 2`] = `
+"import{c as _c}from"react/compiler-runtime";function Greeting(t0){const $=_c(9);const{name,items}=t0;let t1;if($[0]!==name){t1=React.createElement("h1",null,"Hello ",name);$[0]=name;$[1]=t1}else{t1=$[1]}let t2;if($[2]!==items){t2=items.map(_temp);$[2]=items;$[3]=t2}else{t2=$[3]}let t3;if($[4]!==t2){t3=React.createElement("ul",null,t2);$[4]=t2;$[5]=t3}else{t3=$[5]}let t4;if($[6]!==t1||$[7]!==t3){t4=React.createElement("div",null,t1,t3);$[6]=t1;$[7]=t3;$[8]=t4}else{t4=$[8]}return t4}function _temp(item){return React.createElement("li",{key:item},item)}export default Greeting;//# sourceMappingURL=script.js.map
+"
+`;
+
 exports[`Fails gracefully on broken markup 1`] = `
 {
   "status": 1,

--- a/packages/integration/__tests__/__snapshots__/crafty-preset-swc-rspack.js.snap
+++ b/packages/integration/__tests__/__snapshots__/crafty-preset-swc-rspack.js.snap
@@ -306,6 +306,37 @@ exports[`Does not transpile on modern browsers 2`] = `
 //# sourceMappingURL=myBundle.min.js.map"
 `;
 
+exports[`Enables the React Compiler 1`] = `
+{
+  "status": 0,
+  "stdall": "
+[__:__:__] Starting Crafty __version__...
+[__:__:__] Files will be stored in:
+            js: __PATH__/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-rspack/react-compiler/dist/js
+[__:__:__] Starting 'default' ...
+[__:__:__] Starting 'js' ...
+[__:__:__] Starting 'js_myBundle' ...
+asset myBundle.min.js ___ KiB [emitted] (name: default)
+Entrypoint default ___ KiB = myBundle.min.js
+chunk (runtime: default) myBundle.min.js (default) ___ KiB (javascript) ___ KiB (runtime) [entry] [rendered]
+  dependent modules ___ KiB [dependent] 1 module
+  ./js/script.js ___ KiB [built] [code generated]
+
+  Compiled successfully!
+  Δt ____ms
+
+[__:__:__] Finished 'js_myBundle' after ____ ms
+[__:__:__] Finished 'js' after ____ ms
+[__:__:__] Finished 'default' after ____ ms
+",
+}
+`;
+
+exports[`Enables the React Compiler 2`] = `
+"!function(e,t){if("object"==typeof exports&&"object"==typeof module)module.exports=t(require("react/compiler-runtime"));else if("function"==typeof define&&define.amd)define(["react/compiler-runtime"],t);else{var r="object"==typeof exports?t(require("react/compiler-runtime")):t(e["react/compiler-runtime"]);for(var n in r)("object"==typeof exports?exports:e)[n]=r[n]}}(self,function(e){return function(){"use strict";var t={952:function(t){t.exports=e}},r={};function n(e){var o=r[e];if(void 0!==o)return o.exports;var u=r[e]={exports:{}};return t[e](u,u.exports,n),u.exports}n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,{a:t}),t},n.d=function(e,t,r){var o=function(t,r){for(var o in t)if(n.o(t,o)&&!n.o(e,o)){var u={enumerable:!0};u[r]=t[o],Object.defineProperty(e,o,u)}};o(t,"get"),o(r,"value")},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.r=function(e){"u">typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})};var o={};n.r(o);var u=n(952);function i(e){return React.createElement("li",{key:e},e)}return o.default=function(e){let t,r,n,o,c=(0,u.c)(9),{name:l,items:a}=e;return c[0]!==l?(t=React.createElement("h1",null,"Hello ",l),c[0]=l,c[1]=t):t=c[1],c[2]!==a?(r=a.map(i),c[2]=a,c[3]=r):r=c[3],c[4]!==r?(n=React.createElement("ul",null,r),c[4]=r,c[5]=n):n=c[5],c[6]!==t||c[7]!==n?(o=React.createElement("div",null,t,n),c[6]=t,c[7]=n,c[8]=o):o=c[8],o},o}()});
+//# sourceMappingURL=myBundle.min.js.map"
+`;
+
 exports[`Fails gracefully on broken markup 1`] = `
 {
   "status": 1,

--- a/packages/integration/__tests__/__snapshots__/crafty-preset-swc-webpack.js.snap
+++ b/packages/integration/__tests__/__snapshots__/crafty-preset-swc-webpack.js.snap
@@ -326,6 +326,39 @@ exports[`Does not transpile on modern browsers 2`] = `
 //# sourceMappingURL=myBundle.min.js.map"
 `;
 
+exports[`Enables the React Compiler 1`] = `
+{
+  "status": 0,
+  "stdall": "
+[__:__:__] Starting Crafty __version__...
+[__:__:__] Files will be stored in:
+            js: __PATH__/packages/integration-fixtures-cjs/fixtures/crafty-preset-swc-webpack/react-compiler/dist/js
+[__:__:__] Starting 'default' ...
+[__:__:__] Starting 'js' ...
+[__:__:__] Starting 'js_myBundle' ...
+asset myBundle.min.js ___ KiB [emitted] [minimized] (name: default)
+  sourceMap myBundle.min.js.map ___ KiB [emitted] [dev] (auxiliary name: default)
+Entrypoint default ___ KiB (___ KiB) = myBundle.min.js 1 auxiliary asset
+chunk (runtime: default) myBundle.min.js (default) ___ KiB (javascript) ___ KiB (runtime) [entry] [rendered]
+  runtime modules ___ KiB 4 modules
+  dependent modules ___ KiB [dependent] 1 module
+  ./js/script.js ___ KiB [built] [code generated]
+
+  Compiled successfully!
+  Δt ____ms
+
+[__:__:__] Finished 'js_myBundle' after ____ ms
+[__:__:__] Finished 'js' after ____ ms
+[__:__:__] Finished 'default' after ____ ms
+",
+}
+`;
+
+exports[`Enables the React Compiler 2`] = `
+"!function(e,t){if("object"==typeof exports&&"object"==typeof module)module.exports=t(require("react/compiler-runtime"));else if("function"==typeof define&&define.amd)define(["react/compiler-runtime"],t);else{var r="object"==typeof exports?t(require("react/compiler-runtime")):t(e["react/compiler-runtime"]);for(var n in r)("object"==typeof exports?exports:e)[n]=r[n]}}(self,function(e){return function(){"use strict";var t={952:function(t){t.exports=e}},r={};function n(e){var o=r[e];if(void 0!==o)return o.exports;var u=r[e]={exports:{}};return t[e](u,u.exports,n),u.exports}n.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return n.d(t,{a:t}),t},n.d=function(e,t){for(var r in t)n.o(t,r)&&!n.o(e,r)&&Object.defineProperty(e,r,{enumerable:!0,get:t[r]})},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.r=function(e){"u">typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})};var o={};n.r(o);var u=n(952);function c(e){return React.createElement("li",{key:e},e)}return o.default=function(e){let t,r,n,o,i=(0,u.c)(9),{name:l,items:f}=e;return i[0]!==l?(t=React.createElement("h1",null,"Hello ",l),i[0]=l,i[1]=t):t=i[1],i[2]!==f?(r=f.map(c),i[2]=f,i[3]=r):r=i[3],i[4]!==r?(n=React.createElement("ul",null,r),i[4]=r,i[5]=n):n=i[5],i[6]!==t||i[7]!==n?(o=React.createElement("div",null,t,n),i[6]=t,i[7]=n,i[8]=o):o=i[8],o},o}()});
+//# sourceMappingURL=myBundle.min.js.map"
+`;
+
 exports[`Fails gracefully on broken markup 1`] = `
 {
   "status": 1,

--- a/packages/integration/__tests__/crafty-preset-swc-gulp.js
+++ b/packages/integration/__tests__/crafty-preset-swc-gulp.js
@@ -66,6 +66,26 @@ test("Compiles JavaScript", async () => {
   ).toMatchSnapshot();
 });
 
+test("Enables the React Compiler", async () => {
+  const cwd = await testUtils.getCleanFixtures(
+    "crafty-preset-swc-gulp/react-compiler"
+  );
+
+  const result = await testUtils.run(["run", "default"], cwd);
+
+  expect(result).toMatchSnapshot();
+  expect(result.status).toBe(0);
+
+  expect(testUtils.exists(cwd, "dist/js/script.js")).toBeTruthy();
+  expect(testUtils.exists(cwd, "dist/js/script.js.map")).toBeTruthy();
+
+  // The React Compiler injects an import from `react/compiler-runtime`
+  const content = testUtils.readFile(cwd, "dist/js/script.js");
+  expect(content.includes("react/compiler-runtime")).toBeTruthy();
+
+  expect(testUtils.readForSnapshot(cwd, "dist/js/script.js")).toMatchSnapshot();
+});
+
 test("Compiles JavaScript, keeps runtime external", async () => {
   const cwd = await testUtils.getCleanFixtures(
     "crafty-preset-swc-gulp/compiles-import-runtime"

--- a/packages/integration/__tests__/crafty-preset-swc-rspack.js
+++ b/packages/integration/__tests__/crafty-preset-swc-rspack.js
@@ -20,6 +20,26 @@ test("Compiles JavaScript", async () => {
   expect(testUtils.readForSnapshot(cwd, BUNDLE)).toMatchSnapshot();
 });
 
+test("Enables the React Compiler", async () => {
+  const cwd = await testUtils.getCleanFixtures(
+    "crafty-preset-swc-rspack/react-compiler"
+  );
+
+  const result = await testUtils.run(["run", "default"], cwd);
+
+  expect(result).toMatchSnapshot();
+  expect(result.status).toBe(0);
+
+  expect(testUtils.exists(cwd, BUNDLE)).toBeTruthy();
+  expect(testUtils.exists(cwd, BUNDLE_MAP)).toBeTruthy();
+
+  // The React Compiler injects an import from `react/compiler-runtime`
+  const content = testUtils.readFile(cwd, BUNDLE);
+  expect(content.includes("react/compiler-runtime")).toBeTruthy();
+
+  expect(testUtils.readForSnapshot(cwd, BUNDLE)).toMatchSnapshot();
+});
+
 test("Keeps imports unresolved for SWC Runtime", async () => {
   const cwd = await testUtils.getCleanFixtures(
     "crafty-preset-swc-rspack/compiles-import-runtime"

--- a/packages/integration/__tests__/crafty-preset-swc-webpack.js
+++ b/packages/integration/__tests__/crafty-preset-swc-webpack.js
@@ -20,6 +20,40 @@ test("Compiles JavaScript", async () => {
   expect(testUtils.readForSnapshot(cwd, BUNDLE)).toMatchSnapshot();
 });
 
+test("Enables the React Compiler", async () => {
+  const cwd = await testUtils.getCleanFixtures(
+    "crafty-preset-swc-webpack/react-compiler"
+  );
+
+  const result = await testUtils.run(["run", "default"], cwd);
+
+  expect(result).toMatchSnapshot();
+  expect(result.status).toBe(0);
+
+  expect(testUtils.exists(cwd, BUNDLE)).toBeTruthy();
+  expect(testUtils.exists(cwd, BUNDLE_MAP)).toBeTruthy();
+
+  // The React Compiler injects an import from `react/compiler-runtime`
+  const content = testUtils.readFile(cwd, BUNDLE);
+  expect(content.includes("react/compiler-runtime")).toBeTruthy();
+
+  expect(testUtils.readForSnapshot(cwd, BUNDLE)).toMatchSnapshot();
+});
+
+test("Does not enable the React Compiler unless opted in", async () => {
+  const cwd = await testUtils.getCleanFixtures(
+    "crafty-preset-swc-webpack/react-compiler-disabled"
+  );
+
+  const result = await testUtils.run(["run", "default"], cwd);
+
+  expect(result.status).toBe(0);
+
+  // Without `reactCompiler`, no `react/compiler-runtime` import is injected
+  const content = testUtils.readFile(cwd, BUNDLE);
+  expect(content.includes("react/compiler-runtime")).toBeFalsy();
+});
+
 test("Keeps imports unresolved for SWC Runtime", async () => {
   const cwd = await testUtils.getCleanFixtures(
     "crafty-preset-swc-webpack/compiles-import-runtime"


### PR DESCRIPTION
I implemented opt-in SWC React Compiler support in Crafty, working across all three SWC-backed bundlers.

What changed

Implementation — packages/crafty-preset-react/index.js
The swc hook now enables jsc.transform.reactCompiler when a bundle sets react: { reactCompiler: true }. It's independent of Fast Refresh, runs in both dev and production, and passes the value straight through (so true uses defaults and an object forwards options like target/compilationMode). Since all three bundlers funnel their SWC config through this hook, one change covers webpack, rspack, and gulp. No changes were needed in crafty-commons-swc — reactCompiler is added after the rspack builder strips its unsupported options.

Documentation — packages/crafty-preset-react/README.md
New "React Compiler" section: off by default, how to enable per bundle, combining with Fast Refresh, the options object (target for React 17/18), requirements (React 19 default; @rspack/core ≥ 2.1.0 for rspack), and how to disable.

Tests — 4 integration tests + fixtures
- One test per bundler (crafty-preset-swc-{webpack,rspack,gulp}.js) builds a fixture with reactCompiler: true and asserts the output contains the injected react/compiler-runtime import (the concrete "compiler ran" signal), plus a snapshot.
- One negative test (webpack react-compiler-disabled) proves it's truly opt-in — same React-preset setup without reactCompiler produces no compiler runtime.
- Fixtures use export default Greeting (kept as the UMD library export, so not tree-shaken and no no-console lint noise) with React as an external so the marker stays visible in the minified bundle.

All 4 new tests pass; snapshots contain only my new keys (_c(9) memo caches confirmed in every bundler).

Notes

- Verified @swc/core@1.15.43 supports reactCompiler natively (no @swc/react-compiler companion package needed) and master is on @rspack/core@2.1.1, so no dependency bumps were required.
- I observed pre-existing flakiness unrelated to this change: under a heavily-contended full parallel run, a different webpack/rspack test fails each time on its stdout-ordering snapshot (build log interleaving) — each passes in isolation. My change is inert unless reactCompiler is set. I also cleaned up a spurious Removes unused classes 2 snapshot that got written during that contended run.
- Left your untracked before.txt/after.txt/stats_*.md files untouched.