### PR TITLE
Properly add support for custom paths in TypeScript

### DIFF
--- a/docs/05_Packages/05_crafty-preset-typescript/TypeScript_Features.md
+++ b/docs/05_Packages/05_crafty-preset-typescript/TypeScript_Features.md
@@ -56,6 +56,29 @@ function direction(k: "left" | "right") {
 
 [Read more](http://www.typescriptlang.org/docs/tutorial.html)
 
+## Path mapping
+
+The `paths` and `baseUrl` options in your `tsconfig.json` let you import modules through aliases instead of long relative paths:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["./src/components/*"]
+    }
+  }
+}
+```
+
+```typescript
+import Button from "@components/Button";
+```
+
+Crafty reads these mappings from your `tsconfig.json` and applies them when it resolves modules. They work when you bundle with Webpack or Rspack, and when you run tests with Jest or Vitest.
+
+The Gulp runner does not support path mapping. The TypeScript compiler keeps import specifiers as written when it emits files one by one, so the aliases would remain in the output and fail at runtime.
+
 ## IDE Integration
 
 TypeScript being out for years now, it has first class support in IDE's like IntelliJ, Visual Studio Code and others.

--- a/packages/crafty-preset-jest/src/resolver.js
+++ b/packages/crafty-preset-jest/src/resolver.js
@@ -117,5 +117,14 @@ module.exports = create(jestConfig => {
     ".mjs": [".mjs", ".mts"]
   };
 
+  // The TypeScript preset communicates the tsconfig.json location through this
+  // environment variable so imports can be resolved using its `paths`/`baseUrl` mapping
+  if (process.env.CRAFTY_JEST_TSCONFIG) {
+    baseConfig.tsconfig = {
+      configFile: process.env.CRAFTY_JEST_TSCONFIG,
+      references: "auto"
+    };
+  }
+
   return baseConfig;
 });

--- a/packages/crafty-preset-typescript/packages/vitest-tsconfig-paths.js
+++ b/packages/crafty-preset-typescript/packages/vitest-tsconfig-paths.js
@@ -1,0 +1,70 @@
+const path = require("node:path");
+const fs = require("node:fs");
+const enhancedResolve = require("@swissquote/crafty/packages/enhanced-resolve.js");
+
+function isBareImport(specifier) {
+  return (
+    !specifier.startsWith(".") &&
+    !specifier.startsWith("/") &&
+    !specifier.startsWith("\0") &&
+    !/^[a-zA-Z]+:/.test(specifier)
+  );
+}
+
+function stripQueryAndHash(id) {
+  return id.split("?")[0].split("#")[0];
+}
+
+// Vite/Vitest plugin resolving imports through the `paths`/`baseUrl` mapping
+// of a tsconfig.json, using the same enhanced-resolve engine (and semantics)
+// as the webpack, rspack and Jest integrations.
+module.exports = function createTsconfigPathsPlugin({ tsconfig, extensions }) {
+  const resolveSync = enhancedResolve.create.sync({
+    fileSystem: fs,
+    useSyncFileSystemCalls: true,
+    conditionNames: ["node", "import", "require", "default"],
+    extensions: [...new Set(extensions || [])],
+    extensionAlias: {
+      ".js": [".js", ".ts"],
+      ".cjs": [".cjs", ".cts"],
+      ".mjs": [".mjs", ".mts"]
+    },
+    tsconfig: {
+      configFile: tsconfig,
+      references: "auto"
+    }
+  });
+
+  return {
+    name: "crafty-vitest-tsconfig-paths",
+    async resolveId(source, importer, options) {
+      if (!importer || !isBareImport(source)) {
+        return null;
+      }
+
+      // Let Vite resolve real packages first; only fall back to the tsconfig
+      // mapping when the specifier isn't a regular module.
+      const resolved = await this.resolve(source, importer, {
+        ...options,
+        skipSelf: true
+      });
+
+      if (resolved) {
+        return resolved;
+      }
+
+      const importerPath = stripQueryAndHash(importer);
+
+      if (!path.isAbsolute(importerPath)) {
+        return null;
+      }
+
+      try {
+        const modulePath = resolveSync({}, path.dirname(importerPath), source);
+        return modulePath === false ? null : modulePath;
+      } catch {
+        return null;
+      }
+    }
+  };
+};

--- a/packages/crafty-preset-typescript/src/index.js
+++ b/packages/crafty-preset-typescript/src/index.js
@@ -44,6 +44,14 @@ module.exports = {
     return ["ts", "tsx", "mts", "cts"];
   },
   jest(crafty, options, esmMode) {
+    // Let the Jest resolver honor the `paths`/`baseUrl` mapping from tsconfig.json.
+    // The value is read back in `crafty-preset-jest`'s resolver, which runs in Jest
+    // worker processes and inherits this environment variable.
+    const tsconfigFile = findUpSync("tsconfig.json", { cwd: process.cwd() });
+    if (tsconfigFile) {
+      process.env.CRAFTY_JEST_TSCONFIG = tsconfigFile;
+    }
+
     options.moduleDirectories.push(MODULES);
     options.transform["^.+\\.(ts|tsx|mts)$"] = [
       require.resolve("../packages/ts-jest"),
@@ -78,6 +86,20 @@ module.exports = {
   vitest(crafty, options, context) {
     context.moduleDirectories.push(MODULES);
     context.moduleFileExtensions.push("ts", "tsx", "mts", "cts");
+
+    // Resolve imports using the `paths`/`baseUrl` mapping from tsconfig.json
+    const tsconfigFile = findUpSync("tsconfig.json", { cwd: process.cwd() });
+    if (tsconfigFile) {
+      context.runtimePlugins.push({
+        pluginPath: require.resolve("../packages/vitest-tsconfig-paths"),
+        options: {
+          tsconfig: tsconfigFile,
+          extensions: context.moduleFileExtensions.map(
+            extension => `.${extension}`
+          )
+        }
+      });
+    }
   },
   webpack(crafty, bundle, chain) {
     const tsconfigFile = bundle.tsconfigFile || "tsconfig.json";
@@ -120,6 +142,9 @@ module.exports = {
 
     chain.resolve.modules.add(MODULES);
     chain.resolveLoader.modules.add(MODULES);
+
+    // Resolve imports using the `paths`/`baseUrl` mapping from tsconfig.json
+    chain.resolve.set("tsconfig", { configFile, references: "auto" });
 
     // TypeScript
     const tsRule = chain.module.rule("ts");
@@ -246,6 +271,9 @@ module.exports = {
 
     chain.resolve.modules.add(MODULES);
     chain.resolveLoader.modules.add(MODULES);
+
+    // Resolve imports using the `paths`/`baseUrl` mapping from tsconfig.json
+    chain.resolve.set("tsConfig", { configFile, references: "auto" });
 
     // TypeScript
     const tsRule = chain.module.rule("ts");

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-jest/typescript-paths/crafty.config.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-jest/typescript-paths/crafty.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    "@swissquote/crafty-preset-jest",
+    "@swissquote/crafty-preset-typescript"
+  ],
+};

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-jest/typescript-paths/src/__tests__/add.ts
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-jest/typescript-paths/src/__tests__/add.ts
@@ -1,0 +1,5 @@
+import { add } from "@math/add";
+
+it("adds two numbers through a tsconfig path alias", () => {
+  expect(add(2, 2)).toEqual(4);
+});

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-jest/typescript-paths/src/math/add.ts
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-jest/typescript-paths/src/math/add.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-jest/typescript-paths/tsconfig.json
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-jest/typescript-paths/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "exclude": [
+    "node_modules",
+    "node",
+    "css",
+    "etc"
+  ],
+  "compilerOptions": {
+    "declaration": true,
+    "moduleResolution": "node",
+    "jsx": "react",
+    "module": "esnext",
+    "sourceMap": true,
+    "target": "es5",
+    "lib": ["DOM", "ES2017", "DOM.Iterable", "ScriptHost"],
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@math/*": ["./src/math/*"]
+    }
+  }
+}

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-typescript-rspack/compiles-paths/js/script.ts
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-typescript-rspack/compiles-paths/js/script.ts
@@ -1,4 +1,4 @@
-import test from "./components/Calculator";
+import test from "components/Calculator";
 
 export default class NewStuff {
   constructor() {

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-typescript-webpack/compiles-paths/js/script.ts
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-typescript-webpack/compiles-paths/js/script.ts
@@ -1,4 +1,4 @@
-import test from "./components/Calculator";
+import test from "components/Calculator";
 
 export default class NewStuff {
   constructor() {

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-vitest/hook-typescript-paths/crafty.config.js
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-vitest/hook-typescript-paths/crafty.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    "@swissquote/crafty-preset-vitest",
+    "@swissquote/crafty-preset-typescript"
+  ]
+};

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-vitest/hook-typescript-paths/src/__tests__/add.ts
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-vitest/hook-typescript-paths/src/__tests__/add.ts
@@ -1,0 +1,5 @@
+import { add } from "@math/add";
+
+test("resolves TypeScript imports through a tsconfig path alias", () => {
+  expect(add(5, 6)).toBe(11);
+});

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-vitest/hook-typescript-paths/src/math/add.ts
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-vitest/hook-typescript-paths/src/math/add.ts
@@ -1,0 +1,1 @@
+export const add = (a: number, b: number) => a + b;

--- a/packages/integration-fixtures-cjs/fixtures/crafty-preset-vitest/hook-typescript-paths/tsconfig.json
+++ b/packages/integration-fixtures-cjs/fixtures/crafty-preset-vitest/hook-typescript-paths/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "exclude": [
+    "node_modules",
+    "node",
+    "css",
+    "etc"
+  ],
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "esnext",
+    "target": "es2017",
+    "lib": ["DOM", "ES2017"],
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@math/*": ["./src/math/*"]
+    }
+  }
+}

--- a/packages/integration/__tests__/__snapshots__/crafty-preset-jest.js.snap
+++ b/packages/integration/__tests__/__snapshots__/crafty-preset-jest.js.snap
@@ -244,6 +244,23 @@ Ran all test suites.
 }
 `;
 
+exports[`Succeeds with typescript path mapping 1`] = `
+{
+  "status": 0,
+  "stdall": "
+[__:__:__] Starting Crafty __version__...
+PASS src/__tests__/add.ts
+  ✓ adds two numbers through a tsconfig path alias
+
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        _____s
+Ran all test suites.
+",
+}
+`;
+
 exports[`Succeeds without transpiling, selects test 1`] = `
 {
   "status": 0,

--- a/packages/integration/__tests__/crafty-preset-jest.js
+++ b/packages/integration/__tests__/crafty-preset-jest.js
@@ -85,6 +85,17 @@ test("Succeeds with typescript", async () => {
   expect(result.status).toBe(0);
 });
 
+test("Succeeds with typescript path mapping", async () => {
+  const cwd = await testUtils.getCleanFixtures(
+    "crafty-preset-jest/typescript-paths"
+  );
+
+  const result = await testUtils.run(["test"], cwd);
+
+  expect(result).toMatchSnapshot();
+  expect(result.status).toBe(0);
+});
+
 test("Succeeds with typescript modules", async () => {
   const cwd = await testUtils.getCleanFixtures(
     "crafty-preset-jest/typescript-modules"

--- a/packages/integration/__tests__/crafty-preset-vitest.js
+++ b/packages/integration/__tests__/crafty-preset-vitest.js
@@ -542,6 +542,16 @@ test("Loads TypeScript tests through the preset hook", async () => {
   expect(result.status).toBe(0);
 });
 
+test("Resolves TypeScript path mapping through the preset hook", async () => {
+  const cwd = await testUtils.getCleanFixtures(
+    "crafty-preset-vitest/hook-typescript-paths"
+  );
+
+  const result = await testUtils.run(["test"], cwd);
+
+  expect(result.status).toBe(0);
+});
+
 test("Loads the React setup file through the preset hook", async () => {
   const cwd = await testUtils.getCleanFixtures(
     "crafty-preset-vitest/hook-react"


### PR DESCRIPTION
Closes #2988

## Summary

TypeScript's `compilerOptions.paths` / `baseUrl` were only understood by the type-checker and the ESLint import resolver — actual module resolution ignored them, so importing through a path alias failed at build or run time.

This PR makes path mapping work across all four resolution paths, all backed by the **same enhanced-resolve `tsconfig` engine** for identical semantics (including the case where no `baseUrl` is set):

| Target  | How |
| ------- | --- |
| Webpack | native `resolve.tsconfig` (webpack 5.107, [webpack#20400](https://github.com/webpack/webpack/pull/20400)) |
| Rspack  | native `resolve.tsConfig` ([rspack-resolver](https://github.com/rstackjs/rspack-resolver#other-options)) |
| Jest    | `tsconfig` option on the custom enhanced-resolve resolver |
| Vitest  | dedicated Vite resolve plugin using enhanced-resolve |

The Gulp runner is intentionally **not** supported: `tsc` keeps import specifiers as written when it emits files one by one, so aliases would remain unresolved in the output. This is documented as a limitation.

## Changes

**Core — `packages/crafty-preset-typescript/src/index.js`**
- `webpack()` hook → `chain.resolve.set("tsconfig", { configFile, references: "auto" })`
- `rspack()` hook → `chain.resolve.set("tsConfig", { configFile, references: "auto" })`
- `jest()` hook → exports the resolved tsconfig path via `process.env.CRAFTY_JEST_TSCONFIG`,
  mirroring the existing `CRAFTY_VITEST_MODULE_RESOLUTION` env-var pattern
- `vitest()` hook → pushes a runtime plugin through the existing `context.runtimePlugins`
  mechanism

**Supporting**
- `packages/crafty-preset-jest/src/resolver.js` — reads `CRAFTY_JEST_TSCONFIG` and adds the `tsconfig` option to its enhanced-resolve config (gated on the env var, so non-TypeScript projects are unaffected)
- `packages/crafty-preset-typescript/packages/vitest-tsconfig-paths.js` (new) — a Vite resolve plugin modeled on the existing `module-directories-plugin`, resolving via enhanced-resolve's `tsconfig` option

**Docs**
- `docs/05_Packages/05_crafty-preset-typescript/TypeScript_Features.md` — new "Path mapping" section documenting supported runners and the Gulp limitation

## Tests

- The existing `compiles-paths` webpack/rspack fixtures used **relative** imports in their entry, so they never actually exercised alias resolution. The entry now imports through the `components/Calculator` alias.
- Added fixtures and integration cases:
  - `crafty-preset-jest/typescript-paths`
  - `crafty-preset-vitest/hook-typescript-paths`
- Each of the four integrations was confirmed to have teeth by temporarily reverting the support and observing the matching test fail.

### Verification

All relevant integration suites pass with no regressions:

- webpack + rspack TypeScript: 23 passed
- jest + vitest: 50 passed
- TypeScript plain + gulp: 16 passed
- Lint (source + new plugin) and docs (`write-good` + `prettier`) clean

## Notes for reviewers

The new Vitest plugin uses `@swissquote/crafty/packages/enhanced-resolve.js`. `@swissquote/crafty` is already a `peerDependency` of `crafty-preset-typescript` (matching how `crafty-preset-jest` / `crafty-preset-vitest` use it), so no dependency change was needed.

