### PR TITLE
Transform dependencies whose only ESM syntax is `export *`

### DIFF
--- a/packages/crafty-preset-jest/package.json
+++ b/packages/crafty-preset-jest/package.json
@@ -12,7 +12,9 @@
   },
   "main": "src/index.js",
   "scripts": {
-    "lint": "node ../crafty-preset-eslint/src/commands/jsLint.js --preset recommended --preset node src"
+    "lint": "node ../crafty-preset-eslint/src/commands/jsLint.js --preset recommended --preset node src",
+    "test": "node --test",
+    "test:ci": "c8 --clean --reporter=text --reporter=lcov --reporter=html --include=src node --test"
   },
   "dependencies": {
     "@babel/core": "7.29.7",
@@ -21,6 +23,10 @@
     "jest-cli": "30.4.2",
     "jest-environment-jsdom": "30.4.1",
     "jest-to-sonar": "1.3.0"
+  },
+  "devDependencies": {
+    "c8": "12.0.0",
+    "expect": "30.4.1"
   },
   "engines": {
     "node": ">=22.12"

--- a/packages/crafty-preset-jest/src/__tests__/esm-transformer.test.js
+++ b/packages/crafty-preset-jest/src/__tests__/esm-transformer.test.js
@@ -1,0 +1,51 @@
+const { test } = require("node:test");
+const { expect } = require("expect");
+
+const esmTransformer = require("../esm-transformer");
+
+// The transformer only applies to dependencies, which live in `node_modules`
+const FILENAME = "/project/node_modules/some-package/index.js";
+
+function transform(code) {
+  return esmTransformer.process(code, FILENAME).code;
+}
+
+test("it converts a file re-exporting everything with `export *`", () => {
+  const code = transform(`export * from "./number.js";`);
+
+  expect(code).not.toContain("export *");
+  expect(code).toContain("require(");
+});
+
+test("it converts a file with named exports", () => {
+  const code = transform(`export { number } from "./number.js";`);
+
+  expect(code).not.toContain("export {");
+  expect(code).toContain("require(");
+});
+
+test("it converts a file with a default export", () => {
+  const code = transform(`export default 2;`);
+
+  expect(code).not.toContain("export default");
+  expect(code).toContain("exports.default");
+});
+
+test("it converts a file with imports", () => {
+  const code = transform(`import number from "./number.js";\nnumber();`);
+
+  expect(code).not.toContain("import number");
+  expect(code).toContain("require(");
+});
+
+test("it leaves a commonjs file untouched", () => {
+  const code = `const number = require("./number.js");\nmodule.exports = number;`;
+
+  expect(transform(code)).toBe(code);
+});
+
+test("it leaves a file without imports or exports untouched", () => {
+  const code = `const number = 2;`;
+
+  expect(transform(code)).toBe(code);
+});

--- a/packages/crafty-preset-jest/src/esm-transformer.js
+++ b/packages/crafty-preset-jest/src/esm-transformer.js
@@ -6,6 +6,16 @@ const THIS_FILE = fs.readFileSync(__filename);
 
 const importExportRegex = /\b(import|export)\b/;
 
+// All the top level declarations that make a file an ES module.
+// `ExportAllDeclaration` is `export * from "./other.js"`, a file containing
+// only those would be left untransformed if it were missing from this list.
+const ESM_DECLARATIONS = new Set([
+  "ImportDeclaration",
+  "ExportNamedDeclaration",
+  "ExportDefaultDeclaration",
+  "ExportAllDeclaration"
+]);
+
 module.exports = {
   getCacheKey(fileData, filename, instance) {
     return crypto
@@ -41,17 +51,14 @@ module.exports = {
     const ast = babel.parseSync(code, options);
 
     // Imports and exports have to be at the first level on a file
-    // This makes it easy for us to traverse the file, a simple filter does the trick
+    // This makes it easy for us to traverse the file, a simple check does the trick
     // If we had to find `import()` statements that would be more complicated, but as
     // They would certainly have an import or export anyway, we're covered.
-    const hasImportOrExport = ast.program.body.filter(
-      item =>
-        item.type === "ImportDeclaration" ||
-        item.type === "ExportNamedDeclaration" ||
-        item.type === "ExportDefaultDeclaration"
+    const hasImportOrExport = ast.program.body.some(item =>
+      ESM_DECLARATIONS.has(item.type)
     );
 
-    if (hasImportOrExport.length === 0) {
+    if (!hasImportOrExport) {
       return { code };
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,6 +3949,8 @@ __metadata:
     "@babel/core": "npm:7.29.7"
     "@babel/plugin-transform-modules-commonjs": "npm:7.29.7"
     "@swissquote/crafty": "npm:1.30.2"
+    c8: "npm:12.0.0"
+    expect: "npm:30.4.1"
     jest-cli: "npm:30.4.2"
     jest-environment-jsdom: "npm:30.4.1"
     jest-to-sonar: "npm:1.3.0"


### PR DESCRIPTION
The Jest ESM transformer parses each `node_modules` file and only converts it to CommonJS when it finds an `Import`, `ExportNamed` or `ExportDefault` declaration at the top level. `ExportAllDeclaration` is missing from that list, so a file whose only statement is `export * from "./other.js"` is returned untouched and Jest fails to parse it:

```
node_modules/some-package/constants/index.js:1
export * from "./defaultProps";
^^^^^^

SyntaxError: Unexpected token 'export'
```

Such a file is easy to produce: a barrel that re-exports a single module. It only breaks when the `export *` is alone, since any other import or export in the same file makes the whole file go through Babel — which is probably why this went unnoticed for so long.

We hit this on a dependency published as ESM, where one `constants/index.js` was nothing but `export * from "./defaultProps";`. Every Jest suite importing the library's barrel failed.

### Changes

- Add `ExportAllDeclaration` to the list of declarations that mark a file as an ES module, and move the list to a `Set` so the check is a `some()` instead of building an intermediate array.
- Add unit tests for `esm-transformer`, covering `export *`, named exports, default exports, imports, and the two early-return paths. The package had no tests, so `test` / `test:ci` scripts were added following the same shape as `crafty-runner-webpack` (`node --test` + `c8`), which makes them run in `run_all.sh`.

### Verification

- The new `export *` test fails on `master` and passes with the fix; the other five pass either way.
- `yarn test:ci` in `crafty-preset-jest`: 6/6 pass.
- The full `crafty-preset-jest` integration suite: 16/16 pass, no snapshot changes.
- `yarn lint` in `crafty-preset-jest`: clean.

I considered adding an integration fixture instead, but the fake dependency would have to sit physically inside a `node_modules` directory to match the transformer's pattern — a workspace package is symlinked, so Jest resolves its realpath and the transform never applies. Since `node_modules` is gitignored repo-wide, a unit test seemed like the more robust option.