### PR TITLE
Harden GitHub Actions permissions and opt in to `allow-unsafe-pr-checkout`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   documentation:
     runs-on: ubuntu-latest
+    # Needed by github-pages-deploy-action to push to the gh-pages branch
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v7
       with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     if: success()
     permissions:
-      id-token: write
       contents: read
     steps:
     # Commit is needed to check coverage files against content
@@ -21,6 +20,9 @@ jobs:
       uses: actions/checkout@v7
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        # This job executes PR code, so the token must not be left in .git/config
+        persist-credentials: false
+        allow-unsafe-pr-checkout: true
     - name: ⬢ Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
@@ -101,6 +103,9 @@ jobs:
       uses: actions/checkout@v7
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        # This job executes PR code, so the token must not be left in .git/config
+        persist-credentials: false
+        allow-unsafe-pr-checkout: true
     - name: ⬢ Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
@@ -130,14 +135,16 @@ jobs:
           **/coverage/sonar-report.xml
           !node_modules/**
 
-  # ─── Job: uploads coverage using secrets, does NOT run PR code ─────────
+  # ─── Job: uploads coverage using SONAR_TOKEN. Checks out PR code and feeds
+  # it to the scanner, but never executes it (no install/build/test here).
+  # SONAR_TOKEN is therefore exposed to an attacker-controlled workspace: keep
+  # it scoped to analysis of this project only. ─────────
   static_analysis:
     name: "🔬 Static Analysis"
     needs: build
     runs-on: ubuntu-latest
     if: success()
     permissions:
-      id-token: write
       contents: read
     steps:
     # Commit is needed to check coverage files against content
@@ -145,6 +152,8 @@ jobs:
       uses: actions/checkout@v7
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        persist-credentials: false
+        allow-unsafe-pr-checkout: true
         # Disabling shallow clone is needed by SonarQube
         fetch-depth: 0
     - name: ⬇️ Download reports


### PR DESCRIPTION
`actions/checkout@v7` [now refuses by default](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/) to check out a fork PR's head ref when the workflow was triggered by `pull_request_target`. `nodejs.yml` does exactly that in three jobs, so fork PRs no longer get CI.

Opting back in with `allow-unsafe-pr-checkout: true` is the documented escape hatch, but GitHub's precondition is that the checked-out code is *never executed*. Our `lint` and `build` jobs do execute it (`yarn install` with `enableScripts: true`, `yarn build`, `yarn test:ci`). So rather than flip the flag on its own, this PR first removes everything worth stealing from those jobs.

Note this only ever affected fork PRs — 59 of our last 60 PRs came from branches on `swissquote/crafty`, which the v7 block does not apply to.

## What changed

### 1. Removed `id-token: write` from `lint` and `static_analysis`

Neither job consumes OIDC; the permission was copy-paste. It was also the single most dangerous thing in the workflow: under `pull_request_target` the OIDC subject is `repo:swissquote/crafty:ref:refs/heads/master`, so arbitrary PR code could have minted a token asserting our default branch's identity to any relying party that trusts it.

### 2. Added `persist-credentials: false` to all three PR-head checkouts

`persist-credentials` still defaults to `true` in v7, which writes `GITHUB_TOKEN` into `.git/config` as an `http.extraheader`. Any code running afterwards — a `postinstall` script, a test, an ESLint plugin — could read it straight off disk. A `permissions:` block controls the token's *scopes*, not whether it is sitting in the workspace. (This is what zizmor flags as `artipacked`.)

Verified this breaks nothing: `yarn.lock` has zero git-protocol resolutions, so `yarn install` does no authenticated git traffic, and `fetch-depth: 0` is unaffected — the flag governs whether credentials are left behind *after* checkout, not the fetch itself.

### 3. Added `allow-unsafe-pr-checkout: true` to `lint`, `build` and `static_analysis`

With the two changes above, what remains reachable by fork PR code is:

- **`lint` / `build`** — only `ACTIONS_RUNTIME_TOKEN`, which is ambient in every step regardless of `permissions:` and grants artifact read/write scoped to the run (cache is read-only under `pull_request_target`). The artifacts involved are already produced by that same PR code, so there is no escalation. Risk is now essentially equivalent to plain `pull_request`.
- **`static_analysis`** — holds `SONAR_TOKEN`. See "Accepted risk" below.
- **`size_report`** — no checkout at all, so its `pull-requests: write` / `checks: write` token is never exposed to PR code. It reads the report via `fs` rather than interpolating `${{ }}` into the `github-script` body, so there is no template injection. Left unchanged.

Secrets remain unreachable in `lint` / `build` by construction: under `pull_request_target` the workflow file comes from `master`, so a PR author cannot add an `env:` block referencing them.

### 4. Explicit `permissions:` blocks on the other three workflows

`benchmark.yml`, `codeql-analysis.yml` and `documentation.yml` declared no permissions and were running on the repo default, which is currently **write**. None of them are exposed to untrusted code (none trigger on PRs from forks), but they need explicit blocks before we can tighten that default — see follow-ups.

| Workflow / job | Permissions |
| --- | --- |
| `nodejs` / `lint` | `contents: read` |
| `nodejs` / `build` | `contents: read` |
| `nodejs` / `static_analysis` | `contents: read` |
| `nodejs` / `size_report` | `pull-requests: write`, `checks: write` |
| `codeql` / `analyze` | `actions: read`, `contents: read`, `security-events: write` |
| `documentation` | `contents: write` |
| `benchmark` | `contents: read` |

### 5. Fixed a misleading comment

The `static_analysis` job was labelled "does NOT run PR code". It does check out PR code and feed it to the scanner — it just never executes it. The comment now says that, and records why the token's scope matters.

## Accepted risk

`static_analysis` runs the Sonar scanner with `SONAR_TOKEN` over a workspace containing attacker-controlled files, including `sonar-project.properties` — which is scanner *configuration*. A fork PR can therefore influence how the scanner runs. The scanner binary is also auto-downloaded (`scannerVersion` defaults to `8.1.0.6389`), so the blast radius is defined by third-party internals rather than by anything in this repo.

We are accepting this on the basis that `SONAR_TOKEN` is a project-scoped analysis token for `crafty` on a public project, where a leak means someone can submit bogus analyses for one public project. **This assumption needs confirming** — if it is a user token bound to a `swissquote` member, it inherits that member's org permissions (including access to private projects) and should be rotated to a project analysis token before this merges.

If we would rather not carry the risk at all, the alternative is to gate the job on the PR not coming from a fork:

```yaml
static_analysis:
  if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
```

Same-repo PRs (59 of our last 60) keep full Sonar decoration, fork PRs get analysed on the `push` to `master` after merge, and the v7 block never fires for that job — so it would not need `allow-unsafe-pr-checkout` at all.

## Follow-ups (after merge — order matters)

Set **Settings → Actions → General → Workflow permissions** to read-only, and uncheck "Allow GitHub Actions to create and approve pull requests" (currently `true`).

This must happen **after** this PR merges, not before: the permission blocks added in item 4 only take effect once they are on `master`. Flipping the default first would 403 the `gh-pages` deploy in `documentation.yml` and the SARIF upload in `codeql-analysis.yml`, including its weekly `23 8 * * 0` cron run.

Once the default is read-only, a future job added without a `permissions:` block fails loudly instead of silently receiving a write-capable token in a workflow that now deliberately executes fork code.

## Testing

- All four workflow files parse as valid YAML, and job-level permissions resolve to the table above.
- Worth confirming on a real fork PR that `lint` / `build` / `static_analysis` check out and complete, since that path is what the v7 default was blocking.

