### PR TITLE
Set a real Date as the CSS output's modification time

### DIFF
--- a/packages/crafty-preset-postcss/src/touch.js
+++ b/packages/crafty-preset-postcss/src/touch.js
@@ -8,8 +8,9 @@ module.exports = function() {
         return cb(null, file);
       }
 
-      file.stat.mtime = Date.now();
-      file.stat.ctime = Date.now();
+      const now = new Date();
+      file.stat.mtime = now;
+      file.stat.ctime = now;
 
       return cb(null, file);
     }

--- a/packages/integration/__tests__/crafty-preset-postcss-gulp.js
+++ b/packages/integration/__tests__/crafty-preset-postcss-gulp.js
@@ -127,6 +127,22 @@ test("Compiles CSS", async () => {
   );
 });
 
+test("Compiles CSS with a usable modification time", async () => {
+  const cwd = await testUtils.getCleanFixtures(
+    "crafty-preset-postcss-gulp/compiles"
+  );
+  const before = Date.now();
+
+  const result = await testUtils.run(["run", "default"], cwd);
+
+  expect(result.status).toBe(0);
+
+  // A Number of milliseconds here is read as seconds and clamps, giving every build the same mtime.
+  const { mtimeMs } = fs.statSync(path.join(cwd, BUNDLED_CSS));
+  expect(mtimeMs).toBeGreaterThanOrEqual(before - 1000);
+  expect(mtimeMs).toBeLessThanOrEqual(Date.now() + 1000);
+});
+
 test("Compiles CSS, configuration has overrides", async () => {
   const cwd = await testUtils.getCleanFixtures(
     "crafty-preset-postcss-gulp/compiles-with-overrides"


### PR DESCRIPTION
`crafty-preset-postcss`'s `touch.js` assigns `Date.now()` — a Number of milliseconds — where vinyl's `stat` expects a `Date`.

`fs.utimes` reads a numeric argument as **seconds**, so the timestamp is written about a thousand times too far in the future and the filesystem clamps it to its ceiling. Every out-of-range value clamps to the *same* ceiling, so **every build stamps the identical mtime** — on ext4 `15032385535` (`0x37FFFFFFF`), which reads as 2446-05-10.

```console
$ stat -c '%Y %s' dist/css/app.min.css
15032385535 92503
$ # rebuild
$ stat -c '%Y %s' dist/css/app.min.css
15032385535 92503
```

The `.map` written beside it and every `.js` artifact carry ordinary mtimes; only the CSS output is affected.

### Why it matters

This defeats the purpose of the file. Touching the output exists so downstream consumers notice a rebuild, and a timestamp that never moves is the one value that stops them.

Anything deciding *"has this changed?"* from `(last-modified, size)` sees no change unless the byte count also changed. We met it through Tomcat's static resource cache: a stylesheet edit that keeps the length is served stale indefinitely while the file on disk is already correct. Ordinary value tweaks are exactly that shape — `40px` → `48px`.

It presents as intermittent, because length-changing edits work fine.

### Reproducing it, without crafty

```js
const fs = require("fs");
fs.writeFileSync("probe", "x");

fs.utimesSync("probe", Date.now(), Date.now());   // what touch.js assigns
console.log(Math.trunc(fs.statSync("probe").mtimeMs / 1000));
// 15032385535   — the clamp, and the same number every run

fs.utimesSync("probe", new Date(), new Date());
console.log(Math.trunc(fs.statSync("probe").mtimeMs / 1000));
// 1786883479    — now
```

### The change

One `new Date()` for both fields rather than two `Date.now()` calls, since mtime and ctime should be the same instant.

`file.stat.ctime` is a no-op either way — `fs.futimes` sets only atime and mtime — so I left it alone rather than fold an unrelated removal into this.

### Test

A regression test in `packages/integration`, reusing the existing `crafty-preset-postcss-gulp/compiles` fixture. On the previous behaviour it fails with:

```
AssertionError: expected 15032385535000 to be less than or equal to 1786950940413
```

`yarn lint` clean in both touched workspaces.

### One caveat

The clamp is filesystem-dependent. Somewhere with a wider range you would get a far-future timestamp that still *varies* per build, so this particular cache symptom would not appear — but a file dated 2446 is independently a problem for `find -newer`, `make`, and any incremental tooling comparing against wall-clock time. Notably `gulp-newer`, which this repo forks, decides staleness by mtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)